### PR TITLE
All signs quests fixed

### DIFF
--- a/data/gamedata/quests.xml
+++ b/data/gamedata/quests.xml
@@ -281,7 +281,8 @@
 		CheckAll="0"
 		ConditionToGive="all complete"
 		OnComplete="AddPlayerMoney(10000)"
-		Levels="r3m1 r3m2 r1m4 r1m3 r1m2">
+		OnFail='TDeactivate("trSignPlace");'
+		Levels="r3m1 r3m2 r2m1 r2m2 r1m4 r1m3 r1m2 r1m1">
 		<quest
 			Name="q_PWS1"
 			Automatic="1"
@@ -290,7 +291,7 @@
 			ConditionToGive="all taken"
 			PrecedingQuests="q_PlaceWithSign"
 			OnTake='ShowCircleOnMinimapByName("SignPlace_loc")'
-			Levels="r3m1 r3m2 r1m4 r1m3 r1m2" />
+			Levels="r3m2" />
 
 		<quest
 			Name="q_PWS2"
@@ -299,7 +300,7 @@
 			CheckAll="0"
 			ConditionToGive="all complete"
 			PrecedingQuests="q_PWS1"
-			Levels="r3m1 r3m2 r1m4 r1m3 r1m2" />
+			Levels="r3m1 r3m2 r2m1 r2m2 r1m4 r1m3 r1m2 r1m1" />
 	</quest>
 <!--Root/r3m2/Сюжетные/Преодолеть защитников оракула-->
 	<quest
@@ -667,7 +668,7 @@
 		ConditionToGive="all complete"
 		PrecedingQuests="r2m2_Znaki2_Quest"
 		OnComplete="AddPlayerMoney(750)"
-		Levels="r2m2 r2m1 r1m3 r1m1 r1m2" />
+		Levels="r2m2 r2m1 r1m3 r1m1 r1m2 r1m4 r3m1 r3m2" />
 <!--Root/r2m2/Опциональные/Доставить головы сектантов-->
 	<quest
 		Name="r2m2_HeadsHunterQuest"

--- a/data/if/diz/dialogsglobal.xml
+++ b/data/if/diz/dialogsglobal.xml
@@ -1856,6 +1856,7 @@
 		name="r3m2_AloneDruid1_1_N01"
 		text="Что ты ищешь, путник, в этих убогих местах?"
 		role="NPC"
+		scriptCondition="not(IsQuestTaken('q_VisitDruid')) and GetCurNpc():GetSpokenCount()==0"
 		nextReplies="r3m2_AloneDruid1_1_N02" />
 
 	<Reply
@@ -1866,15 +1867,39 @@
 
 	<Reply
 		name="r3m2_AloneDruid1_1_N03"
-		text="Здесь его нет. Езжай на северо-запад. Может быть, там ты найдёшь свою цель."
+		text="Здесь его нет. Езжай на северо-запад. Может быть, там ты найдёшь свою цель. Ну а мне пора - надо приводить поля в порядок."
 		role="NPC"
 		nextReplies="r3m2_AloneDruid1_1_N04" />
 
 	<Reply
 		name="r3m2_AloneDruid1_1_N04"
-		text="Спасибо."
+		text="А что случилось с твоими полями?"
 		role="PLAYER"
-		scriptResult="EndConversation();" />
+		nextReplies="Dlg_npc_001293" />
+
+	<Reply
+		name="Dlg_npc_001293"
+		text="Кто-то потоптал мои посевы: то ли на грузовике проехался, то ли поджёг, и оставил странные следы."
+		role="NPC"
+		nextReplies="Dlg_pl_001294" />
+
+	<Reply
+		name="Dlg_pl_001294"
+		text="Кажется, я уже встречал что-то похожее. Покажи где твои посевы, я сообщу, куда следует."
+		role="PLAYER"
+		nextReplies="Dlg_npc_001295" />
+
+	<Reply
+		name="Dlg_npc_001295"
+		text="Совсем близко, направо от выезда. Заранее тебе спасибо - за поля и за разговор."
+		role="NPC"
+		nextReplies="Dlg_pl_001296" />
+
+	<Reply
+		name="Dlg_pl_001296"
+		text="Рад буду помочь. Поеду, погляжу на знаки."
+		role="PLAYER"
+		scriptResult="TakeQuest('q_PlaceWithSign'); TActivate('trSignPlace'); GetCurNpc():SetSpokenCount(1); EndConversation()" />
 <!--Root/r3m1/Очистить стоухендж-->
 	<Reply
 		name="Fist_ambush_guard2_1_N01"
@@ -2479,7 +2504,7 @@
 		name="Set_Bar_Druid3_1_N01"
 		text="Я узнал, что ты направляешься к Оракулу?"
 		role="NPC"
-		scriptCondition="QuestStatus('q_VisitDruid')==Q_CANBEGIVEN and QuestStatus('r3m1_ClearSanctuary_ReturnDruid2')==Q_COMPLETED"
+		scriptCondition="QuestStatus('q_VisitDruid')==Q_CANBEGIVEN and QuestStatus('r3m1_ClearSanctuary_ReturnDruid2')==Q_COMPLETED and not(IsQuestTaken('q_PlaceWithSign')) and GetCurNpc():GetSpokenCount( ) == 0"
 		nextReplies="Set_Bar_Druid3_1_N02" />
 
 	<Reply

--- a/data/if/diz/questinfoglobal.xml
+++ b/data/if/diz/questinfoglobal.xml
@@ -1363,6 +1363,10 @@
 		briefDiz="Сообщить в Мидгард ученым о знаках"
 		isMainQuest="0">
 		<Map
+			name="r1m1"
+			targetObjName="ToR1M2" />
+
+		<Map
 			name="r1m2"
 			targetObjName="Midragd" />
 
@@ -2248,6 +2252,10 @@
 		fullDiz="Ученых в Мидгарде заинтересует такая информация. Возможно, мне даже удастся на этом подзаработать деньжат."
 		isMainQuest="0">
 		<Map
+			name="r1m1"
+			targetObjName="ToR1M2" />
+
+		<Map
 			name="r1m2"
 			targetObjName="Midragd" />
 
@@ -2256,12 +2264,23 @@
 			targetObjName="ToR1M2" />
 
 		<Map
+			name="r1m4"
+			targetObjName="ToR1M3" />
+
+		<Map
 			name="r2m1"
 			targetObjName="ToR1M3" />
 
 		<Map
 			name="r2m2"
 			targetObjName="ToR2M1" />
+
+		<Map
+			name="r3m1" />
+
+		<Map
+			name="r3m2"
+			targetObjName="ToR3M1" />
 	</QuestInfo>
 
 	<QuestInfo

--- a/data/maps/r3m1/triggers.xml
+++ b/data/maps/r3m1/triggers.xml
@@ -27,6 +27,7 @@
 				SetCoordinateForQuest( "r1m2_Glagiators_Quest" , CVector(getPos("ToR1M4")))
 				SetCoordinateForQuest( "r1m2_MovemineralToMidgard_Quest" , CVector(getPos("ToR1M4")))
 				SetCoordinateForQuest( "q_PWS2" , CVector(getPos("ToR1M4")))
+				SetCoordinateForQuest( "r2m2_Znaki2Midgard_Quest" , CVector(getPos("ToR1M4")))
 
 
 				SetCoordinateForQuest( "r2m2_GiveDisk2ToOrakul",	CVector(7738.129, 286.901, 4949.968), "r2m1")
@@ -43,6 +44,7 @@
 				SetCoordinateForQuest( "r1m2_Glagiators_Quest" , 			 CVector(getPos("ToR2M1")))
 				SetCoordinateForQuest( "r1m2_MovemineralToMidgard_Quest" ,   CVector(getPos("ToR2M1")))
 				SetCoordinateForQuest( "q_PWS2" , CVector(getPos("ToR2M1")))
+				SetCoordinateForQuest( "r2m2_Znaki2Midgard_Quest" , CVector(getPos("ToR2M1")))
 
 				SetCoordinateForQuest( "r2m2_GiveDisk2ToOrakul",	CVector(2114.268, 235.762, 5967.831), "r2m1")
 				SetCoordinateForQuest( "r2m2_GiveDisk2ToOrakul",	CVector(1444.032, 290.169, 5539.769), "r1m3")
@@ -511,6 +513,8 @@
 				local b = SpawnMessageBox( "8801" )
 				if b == 1 then
 --					println ("Yes")
+					local scp = getObj("Set_Bar_Customer1")
+					if scp:GetSpokenCount()==0 then scp:SetSpokenCount(1) end
 					PassToMap("r3m2", "FromR3M1", -1 )
 				else
 --					println ("No")


### PR DESCRIPTION
Пофикшены квесты со знаками на полях в r2m2 и r3m2.
Теперь их можно провалить только если приехать с этими активными квестами в 4 регион.
Квест со знаками в r3m2 можно взять вне зависимости от того, нужно нам передать посылку Друиду или нет.
Добавлены недостающие маркеры на те карты, где их не было.
НЕ стал исправлять остановку машины в катсцене с осмотром полей в r3m2 и музыку там же, потому что для этого есть отдельный бранч и ишью.
#17 
Тестировать лучше начинать с первого въезда в Рощу, ибо там срабатывает триггер, который ставит этим квестам метки в зависимости от ветки.
Без Лисы [00000012.zip](https://github.com/DeusExMachinaTeam/EM-CommunityPatch/files/6427253/00000012.zip)
С Лисой [00000008.zip](https://github.com/DeusExMachinaTeam/EM-CommunityPatch/files/6427264/00000008.zip)