### PR TITLE
sng prison caravan target

### DIFF
--- a/data/gamedata/quests.xml
+++ b/data/gamedata/quests.xml
@@ -1464,7 +1464,7 @@
 
 		<quest
 			Name="FreeExtremistLeader_Quest3_1"
-			Automatic="1"
+			Automatic="0"
 			SubQuestsCondition="and"
 			CheckAll="0"
 			ConditionToGive="all complete"

--- a/data/maps/r1m4/cinematriggers.xml
+++ b/data/maps/r1m4/cinematriggers.xml
@@ -524,6 +524,7 @@
 		TDeactivate("trCaravan_cam03")           
 		SetCameraBehindPlayerVehicle()
 		CompleteQuest("FreeExtremistLeader_Quest3")
+		TakeQuest("FreeExtremistLeader_Quest3_1")
 		trigger:Deactivate()
 		</script>
 	</trigger>

--- a/data/maps/r1m4/triggers.xml
+++ b/data/maps/r1m4/triggers.xml
@@ -272,6 +272,12 @@
 
 			TDeactivate("trLeaderCaravanDie")
 			TActivate("trLeaderCarDie_End")
+
+			FailQuestIfTaken("TRS_Quest3b")
+			FailQuestIfTaken("FreeExtremistLeader_Quest1")
+			FailQuestIfTaken("FreeExtremistLeader_Quest3_1")
+			FailQuestIfTaken("FreeExtremistLeader_Quest3_2")
+
 			trigger:Deactivate()
 		</script>
 	</trigger>
@@ -288,10 +294,7 @@
 
 			local LeadCar = GetEntityByName("LeaderCar_vehicle_0")
 			if LeadCar then LeadCar:Remove() end
-
-			FailQuestIfTaken("TRS_Quest3b")
-			FailQuestIfTaken("FreeExtremistLeader_Quest3")
-			FailQuestIfTaken("FreeExtremistLeader_Quest1")
+		
 			TakeQuest("TRS_Quest3a")
 
 			trigger:Deactivate()


### PR DESCRIPTION
> Метка на Молоковоз после убийства охранников, к сожалению, так же стабильно не поставилась оба проезда квеста, но с этим видимо ничего не сделать, только следить за журналом. Особенно тут сбивает столку "Задание выполнено", появляющееся после растрела охранников и пропадающая в этот же момент метка с радара.

Немного подправил порядок взятия квестов, и теперь по неведомой мне причине метка нормально переключается.
Сначала она ставится на молоковоз, а потом, после его уничтожения, перескакивает на охрану. Если вручную поменять метку на охрану, то на молоковоз она не перескочит после их уничтожения. Но хотя бы так. Это всяко лучше, чем было.

> Мне кажется невнимательный игрок после этого спокойно может укатить в любом направлении, если молоковоз успел отъехать из зоны видимости.

А потом поймёт, что сделал что-то не так, включит метку и поедет выносить оставшихся врагов. А раньше он и этого не смог бы сделать, потому что метка стояла на координатах конкретных. Тупорылый игрок всегда найдёт, где обосраться. Я и так все эти моменты минимизировал донельзя.

Сейв для тестов: под номером 6 из #254 