### PR TITLE
Yet another globalmap ico fix

### DIFF
--- a/patch/if/dialogs/globalmapwnd.xml
+++ b/patch/if/dialogs/globalmapwnd.xml
@@ -293,6 +293,29 @@
 		</Node>
 
 		<Node
+			name="mainmenu_ico"
+			class="ImageWnd"
+			org="-100.000 -100.000 0.000 0.000"
+			style="512"
+			order="10"
+			id="300000"
+			caption="Control"
+			tip=""
+			backimage=""
+			paneName="defaultWnd"
+			scrollPaneName="Scroll1"
+			paneFlags="0"
+			wrap="2"
+			format="1"
+			font="0"
+			clientEdges="0.000 0.000 0.000 0.000"
+			wndColor="00000000"
+			textColor="ffffffff"
+			image="data\if\ico\GlobalMap\Gmap_Ico_2.dds">
+			<Animations />
+		</Node>
+
+		<Node
 			name="lnHorz0"
 			class="LineWnd"
 			org="70.000 364.000 884.000 2.000"

--- a/remaster/data/if/dialogs_16_9/globalmapwnd.xml
+++ b/remaster/data/if/dialogs_16_9/globalmapwnd.xml
@@ -292,6 +292,29 @@
 			image="data\if\ico\GlobalMap\Gmap_Ico_2.dds">
 			<Animations/>
 		</Node>
+		
+		<Node
+			name="mainmenu_ico"
+			class="ImageWnd"
+			org="-100.000 -100.000 0.000 0.000"
+			style="512"
+			order="10"
+			id="300000"
+			caption="Control"
+			tip=""
+			backimage=""
+			paneName="defaultWnd"
+			scrollPaneName="Scroll1"
+			paneFlags="0"
+			wrap="2"
+			format="1"
+			font="0"
+			clientEdges="0.000 0.000 0.000 0.000"
+			wndColor="00000000"
+			textColor="ffffffff"
+			image="data\if\ico\GlobalMap\Gmap_Ico_2.dds">
+			<Animations/>
+		</Node>
 
 		<Node
 			name="lnHorz0"


### PR DESCRIPTION
Номенклатурно добавил в оба файла globalmapwnd mainmenu_ico и вынес за края экрана. Не считаю, что нужно было прямо выносить за края, достаточно просто ему длину/ширину 0 0 было сделать, но ты настоял. 
Иконка эта начинает отображаться только тогда, когда ты в режиме игры посещаешь карту меню (но так как она за краями экрана, она не покажется вообще никогда). Просто инфа для тестов.