### PR TITLE
ural_drop_r1m4_r2_r3_fix

### DIFF
--- a/patch/gamedata/gameobjects/infection.xml
+++ b/patch/gamedata/gameobjects/infection.xml
@@ -448,7 +448,7 @@ $Id: Infection.xml,v 1.48 2005/11/28 07:43:57 anton Exp $
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale HunterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="electronics"
+			WaresPrototypes="fuel machinery electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 		<Description 
@@ -491,7 +491,7 @@ $Id: Infection.xml,v 1.48 2005/11/28 07:43:57 anton Exp $
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale HunterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="electronics"
+			WaresPrototypes="fuel machinery electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 		<Description 
@@ -599,12 +599,12 @@ $Id: Infection.xml,v 1.48 2005/11/28 07:43:57 anton Exp $
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale HunterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="electronics"
+			WaresPrototypes="fuel oil electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale FighterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="electronics"
+			WaresPrototypes="fuel oil electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 
@@ -656,12 +656,12 @@ $Id: Infection.xml,v 1.48 2005/11/28 07:43:57 anton Exp $
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale HunterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="electronics"
+			WaresPrototypes="fuel oil electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale FighterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="electronics"
+			WaresPrototypes="fuel oil electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 
@@ -712,12 +712,12 @@ $Id: Infection.xml,v 1.48 2005/11/28 07:43:57 anton Exp $
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale HunterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="electronics"
+			WaresPrototypes="bottle tobacco electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale FighterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="electronics"
+			WaresPrototypes="bottle tobacco electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 
@@ -768,12 +768,12 @@ $Id: Infection.xml,v 1.48 2005/11/28 07:43:57 anton Exp $
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale HunterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="electronics"
+			WaresPrototypes="bottle tobacco electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale FighterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="electronics"
+			WaresPrototypes="bottle tobacco electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 
@@ -825,12 +825,12 @@ $Id: Infection.xml,v 1.48 2005/11/28 07:43:57 anton Exp $
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale HunterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="book electronics"
+			WaresPrototypes="bottle tobacco book electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale FighterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="book electronics"
+			WaresPrototypes="bottle tobacco book electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 
@@ -911,12 +911,12 @@ $Id: Infection.xml,v 1.48 2005/11/28 07:43:57 anton Exp $
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale HunterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="book electronics"
+			WaresPrototypes="bottle tobacco book electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale FighterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="book electronics"
+			WaresPrototypes="bottle tobacco book electronics"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 
@@ -965,12 +965,12 @@ $Id: Infection.xml,v 1.48 2005/11/28 07:43:57 anton Exp $
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale HunterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="book"
+			WaresPrototypes="bottle tobacco book"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 		<Description 
 			VehiclesPrototypes	="UralForSale FighterEnemySpawn ScoutEnemySpawn" 	
-			WaresPrototypes="book"
+			WaresPrototypes="bottle tobacco book"
 			GunAffixGeneratorPrototype="villageaffixGenerator"
 			PartOfSchwartz="0.3" />
 


### PR DESCRIPTION
Собственно, смотри что я сделал:
Теперь в Хеле, Лимбриуме, Аранжане, Роще Дуридов и Инготте уралы дропают товары, которые прописаны в дропе их меньших друзей - бутылки, табак, нефть, топливо, рабочее оборудование (в зависимости от конкретной локации).
Раньше у них была прописана только электроника, и они не дропали ничего кроме говнопушек (ибо электроника дорого).
Учитывая, что количество лута и так немного уменьшилось в патче, никаких проблем с обжконтом это вызывать не должно. По крайней мере у меня в ISL это не вызвало абсолютно никаких проблем.