### PR TITLE
Выключил триггер в r1m3

### DIFF
--- a/patch/maps/r1m3/triggers.xml
+++ b/patch/maps/r1m3/triggers.xml
@@ -386,6 +386,8 @@
 			TActivate( "BOSSOILMINENDCINIMATIC" )
 
 			CompleteQuest( "d_DriveBanditFromOilMine_Quest" )
+
+			trigger:Deactivate()
 			
 		</script>
 	</trigger>


### PR DESCRIPTION
После того, как мы отбиваем нападение на нефтяную вышку, триггер раньше не деактивировался и при последующих загрузках сейва срал в лог ошибкой. Теперь не срёт.