### PR TITLE
rainmetal, vector and bumblebee reverse fixes

### DIFF
--- a/patch/gamedata/gameobjects/bigguns.xml
+++ b/patch/gamedata/gameobjects/bigguns.xml
@@ -48,13 +48,13 @@ $Id: BigGuns.xml,v 1.43 2005/11/28 07:43:56 anton Exp $
 		BulletPrototype		= "raybullet"
 		ExplosionType		= "MACHINEGUN"
 		FiringEffect		= "none"
-		Damage			= "14"
+		Damage			= "13"
 		FiringRate		= "300"
 		GroupingAngle		= "1.4"
 		FiringRange		= "750"
 		RecoilForce		= "50"
 		
-		ChargeSize     = "50"
+		ChargeSize     = "135"
 		RechargingTime = "3.5"
 
 		Decal				= "DC_BIG_MACHINEGUN"
@@ -162,12 +162,12 @@ $Id: BigGuns.xml,v 1.43 2005/11/28 07:43:56 anton Exp $
 		
 		Decal				= "DC_BIG_MACHINEGUN"
 
-		ChargeSize     = "50"
+		ChargeSize     = "80"
 		RechargingTime = "5"
 
 		Price			= "7680"
                 FiringType		= "Cannon"
-		BlastWavePrototype      = "smallBlastWave"
+		BlastWavePrototype      = "smallBlastWave_rainmetal"
 		Durability		= "100" />
 
 	<Prototype
@@ -236,7 +236,7 @@ $Id: BigGuns.xml,v 1.43 2005/11/28 07:43:56 anton Exp $
 		BulletPrototype		= "someMortarShell"
 		ExplosionType		= "GRENADE"
 		FiringEffect		= "none"
-		Damage			= "120"
+		Damage			= "115"
 		FiringRate		= "70"
 		GroupingAngle		= "2.1"
 		FiringRange		= "600"
@@ -245,8 +245,8 @@ $Id: BigGuns.xml,v 1.43 2005/11/28 07:43:56 anton Exp $
 		ActionDist		= "1000"		
 		InitialVelocity		= "70"
 
-		BlastWavePrototype      = "smallBlastWave"
-		ChargeSize     = "9"
+		BlastWavePrototype      = "smallBlastWave_bumblebee"
+		ChargeSize     = "21"
 		RechargingTime = "6"
 
 		TurningSpeed		= "100"

--- a/patch/gamedata/gameobjects/rockets.xml
+++ b/patch/gamedata/gameobjects/rockets.xml
@@ -118,6 +118,28 @@ $Id: Rockets.xml,v 1.68 2005/11/28 07:43:57 anton Exp $
 
         <Prototype
                 Class                   = "BlastWave"
+                Name                    = "smallBlastWave_rainmetal"
+                Effect                  = "ET_PS_AIRWAVE2"
+                
+                Radius                  = "30.0"
+
+                WaveForceIntensity      = "18.0"
+                WaveDamageIntensity     = "18.0"
+        />
+
+        <Prototype
+                Class                   = "BlastWave"
+                Name                    = "smallBlastWave_bumblebee"
+                Effect                  = "ET_PS_AIRWAVE2"
+                
+                Radius                  = "30.0"
+
+                WaveForceIntensity      = "13.0"
+                WaveDamageIntensity     = "13.0"
+        />
+
+        <Prototype
+                Class                   = "BlastWave"
                 Name                    = "mineBlastWave"
                 Effect                  = "ET_PS_CANNONGROUNDEXPLOSION"
                 

--- a/remaster/data/gamedata/gameobjects/bigguns.xml
+++ b/remaster/data/gamedata/gameobjects/bigguns.xml
@@ -48,13 +48,13 @@ $Id: BigGuns.xml,v 1.43 2005/11/28 07:43:56 anton Exp $
 		BulletPrototype		= "raybullet"
 		ExplosionType		= "MACHINEGUN"
 		FiringEffect		= "none"
-		Damage			= "14"
+		Damage			= "13"
 		FiringRate		= "300"
 		GroupingAngle		= "1.4"
 		FiringRange		= "750"
 		RecoilForce		= "50"
 		
-		ChargeSize     = "50"
+		ChargeSize     = "135"
 		RechargingTime = "3.5"
 
 		Decal				= "DC_BIG_MACHINEGUN"
@@ -162,12 +162,12 @@ $Id: BigGuns.xml,v 1.43 2005/11/28 07:43:56 anton Exp $
 		
 		Decal				= "DC_BIG_MACHINEGUN"
 
-		ChargeSize     = "50"
+		ChargeSize     = "80"
 		RechargingTime = "5"
 
 		Price			= "24580"
                 FiringType		= "Cannon"
-		BlastWavePrototype      = "smallBlastWave"
+		BlastWavePrototype      = "smallBlastWave_rainmetal"
 		Durability		= "100" />
 
 	<Prototype
@@ -236,7 +236,7 @@ $Id: BigGuns.xml,v 1.43 2005/11/28 07:43:56 anton Exp $
 		BulletPrototype		= "someMortarShell"
 		ExplosionType		= "GRENADE"
 		FiringEffect		= "none"
-		Damage			= "120"
+		Damage			= "115"
 		FiringRate		= "70"
 		GroupingAngle		= "2.1"
 		FiringRange		= "600"
@@ -245,8 +245,8 @@ $Id: BigGuns.xml,v 1.43 2005/11/28 07:43:56 anton Exp $
 		ActionDist		= "1000"		
 		InitialVelocity		= "70"
 
-		BlastWavePrototype      = "smallBlastWave"
-		ChargeSize     = "9"
+		BlastWavePrototype      = "smallBlastWave_bumblebee"
+		ChargeSize     = "21"
 		RechargingTime = "6"
 
 		TurningSpeed		= "100"

--- a/remaster/data/gamedata/gameobjects/rockets.xml
+++ b/remaster/data/gamedata/gameobjects/rockets.xml
@@ -118,6 +118,28 @@ $Id: Rockets.xml,v 1.68 2005/11/28 07:43:57 anton Exp $
 
         <Prototype
                 Class                   = "BlastWave"
+                Name                    = "smallBlastWave_rainmetal"
+                Effect                  = "ET_PS_AIRWAVE2"
+                
+                Radius                  = "30.0"
+
+                WaveForceIntensity      = "18.0"
+                WaveDamageIntensity     = "18.0"
+        />
+
+        <Prototype
+                Class                   = "BlastWave"
+                Name                    = "smallBlastWave_bumblebee"
+                Effect                  = "ET_PS_AIRWAVE2"
+                
+                Radius                  = "30.0"
+
+                WaveForceIntensity      = "13.0"
+                WaveDamageIntensity     = "13.0"
+        />
+        
+        <Prototype
+                Class                   = "BlastWave"
                 Name                    = "mineBlastWave"
                 Effect                  = "ET_PS_CANNONGROUNDEXPLOSION"
                 


### PR DESCRIPTION
Увеличил размер обоймы для рейнметала, вектора и шмеля так, чтобы соотношение обоймы и скорострельности осталось оригинальным (в пределах погрешности для сохранения значений, кратных пяти).

Для рейнметала и шмеля созданы дубляжи ударных волн с уменьшенными уроном и интенсивностью для компенсации оригинальных значений.

У шмеля слегка уменьшил стандартный урон в пользу приближения к оригинальному (8100 - оригинальный урон в минуту шмеля без учёта перезарядка, 8400 - было после предыдущих правок, 8050 - стало теперь). Очень слегка компенсируется округлением вверх урона ударной волны.

Вектору тоже слегка уменьшен урон для соответствия оригиналу (3850 - оригинал, 4200 - было, 3900 - стало).