### PR TITLE
e_uralcargo04 fix and firing range gun model fix

### DIFF
--- a/patch/gamedata/gameobjects/vehicleparts.xml
+++ b/patch/gamedata/gameobjects/vehicleparts.xml
@@ -2917,7 +2917,7 @@ $Id: VehicleParts.xml,v 1.80 2005/11/28 07:43:57 anton Exp $
 			Mass				= "50.0"
 			LoadPoints			= "LP_BIG01" >
 			<RepositoryDescription
-				RepositorySize		= "8 9">
+				RepositorySize		= "4 6">
 				<Slot
 					Name		= "BASKET_BIG_GUN_0"
 					Pos		= "10 0"

--- a/patch/gamedata/gameobjects/vehicleparts.xml
+++ b/patch/gamedata/gameobjects/vehicleparts.xml
@@ -917,15 +917,15 @@ $Id: VehicleParts.xml,v 1.80 2005/11/28 07:43:57 anton Exp $
 			ModelFile			= "hunterCab01"
 			ResourceType			= "HUNTER_CABIN"
 			NodeScale			= "1 1 1"
-			Durability			= "150"
-			DurCoeffsForDamageTypes	= "20 0 -25"
+			Durability			= "350"
+			DurCoeffsForDamageTypes	= "20 10 -5"
 			VisibleInEncyclopedia = "false"
 			Mass				= "5.0"
 			EngineHighSound			= "ET_S_ENGINE_HUNTER_1_HIGH"
 			BlowEffect	= "ET_PS_VEH_PART_BLOW_SMALL_CAB"
 			MaxPower			= "120"
 			MaxTorque			= "80"
-			Price				= "10000"	
+			Price				= "5000"	
 			MaxSpeed			= "100.0"
 			LoadPoints			= "LP_GIANT01" >
 				<GroupsHealth
@@ -953,7 +953,7 @@ $Id: VehicleParts.xml,v 1.80 2005/11/28 07:43:57 anton Exp $
 			EngineHighSound		        = "ET_S_ENGINE_HUNTER_1_HIGH"
 			BlowEffect	= "ET_PS_VEH_PART_BLOW_SMALL_CAB"
 			MaxTorque			= "80"
-			Price				= "14000"	
+			Price				= "3000"	
 			MaxSpeed			= "100.0"
 			LoadPoints			= "LP_SML01 LP_BIG01" >
 				<GroupsHealth

--- a/patch/gamedata/gameobjects/vehicleparts.xml
+++ b/patch/gamedata/gameobjects/vehicleparts.xml
@@ -917,15 +917,15 @@ $Id: VehicleParts.xml,v 1.80 2005/11/28 07:43:57 anton Exp $
 			ModelFile			= "hunterCab01"
 			ResourceType			= "HUNTER_CABIN"
 			NodeScale			= "1 1 1"
-			Durability			= "350"
-			DurCoeffsForDamageTypes	= "20 10 -5"
+			Durability			= "150"
+			DurCoeffsForDamageTypes	= "20 0 -25"
 			VisibleInEncyclopedia = "false"
 			Mass				= "5.0"
 			EngineHighSound			= "ET_S_ENGINE_HUNTER_1_HIGH"
 			BlowEffect	= "ET_PS_VEH_PART_BLOW_SMALL_CAB"
 			MaxPower			= "120"
 			MaxTorque			= "80"
-			Price				= "5000"	
+			Price				= "10000"	
 			MaxSpeed			= "100.0"
 			LoadPoints			= "LP_GIANT01" >
 				<GroupsHealth
@@ -953,7 +953,7 @@ $Id: VehicleParts.xml,v 1.80 2005/11/28 07:43:57 anton Exp $
 			EngineHighSound		        = "ET_S_ENGINE_HUNTER_1_HIGH"
 			BlowEffect	= "ET_PS_VEH_PART_BLOW_SMALL_CAB"
 			MaxTorque			= "80"
-			Price				= "3000"	
+			Price				= "14000"	
 			MaxSpeed			= "100.0"
 			LoadPoints			= "LP_SML01 LP_BIG01" >
 				<GroupsHealth

--- a/remaster/data/gamedata/gameobjects/gadgets.xml
+++ b/remaster/data/gamedata/gameobjects/gadgets.xml
@@ -119,7 +119,7 @@ $Id: Gadgets.xml,v 1.25 2005/11/17 06:42:59 anton Exp $
 		ResourceType		= "GADGET_WEAPON" 
 		Price			= "2350"	
 		Modifications		= "MachineGun FiringRange 20; Cannon FiringRange 20; ShotGun FiringRange 20"
-		ModelFile		= "gadget_10"
+		ModelFile		= "gadget_02"
 		SkinNum			= "0"
                 />
  

--- a/remaster/data/if/ico_hd/modelicons.xml
+++ b/remaster/data/if/ico_hd/modelicons.xml
@@ -133,18 +133,18 @@
    <Item id="cooling_system_guns" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_bul.dds" file1=""/>
    <Item id="cooling_system_energy" 		file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_enrg.dds" file1=""/>
    <Item id="cooling_system_explosion" 	file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_exp.dds" file1=""/>
-   <Item id="firing_rate_guns" 				file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_bul.dds" file1=""/>
-   <Item id="firing_rate_energy" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_enrg.dds" file1=""/>
+   <Item id="firing_rate_guns" 				file="data\if\ico_hd\InventoryDlg\Gadgets\gadget3_bul.dds" file1=""/>
+   <Item id="firing_rate_energy" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget3_enrg.dds" file1=""/>
    <Item id="grouping_angle_guns" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_bul.dds" file1=""/>
    <Item id="add_damage_guns" 				file="data\if\ico_hd\InventoryDlg\Gadgets\gadget4_bul.dds" file1=""/>
    <Item id="add_damage_energy" 				file="data\if\ico_hd\InventoryDlg\Gadgets\gadget4_enrg.dds" file1=""/>
    <Item id="add_damage_explosion" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget4_exp.dds" file1=""/>
-   <Item id="firing_range_guns"  			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_bul.dds" file1=""/>
+   <Item id="firing_range_guns"  			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget7_bul.dds" file1=""/>
    <Item id="cooling_system_guns2" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_v2_bul.dds" file1=""/>
    <Item id="cooling_system_energy2" 		file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_v2_enrg.dds" file1=""/>
    <Item id="cooling_system_explosion2" 	file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_v2_exp.dds" file1=""/>
-   <Item id="firing_rate_guns2" 			   file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_v2_bul.dds" file1=""/>
-   <Item id="firing_rate_energy2" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_v2_enrg.dds" file1=""/>
+   <Item id="firing_rate_guns2" 			   file="data\if\ico_hd\InventoryDlg\Gadgets\gadget3_v2_bul.dds" file1=""/>
+   <Item id="firing_rate_energy2" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget3_v2_enrg.dds" file1=""/>
    <Item id="grouping_angle_guns2" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_v2_bul.dds" file1=""/>
    <Item id="add_damage_guns2" 				file="data\if\ico_hd\InventoryDlg\Gadgets\gadget4_v2_bul.dds" file1=""/>
    <Item id="add_damage_energy2" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget4_v2_enrg.dds" file1=""/>
@@ -164,16 +164,16 @@
    <Item id="additional_fuel_tank2" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget2_v2.dds" file1=""/>
    <Item id="additional_fuel_tank2_add_damage_guns" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget2_v3.dds" file1=""/>
    
-   <Item id="additional_torque" 			file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3.dds" file1=""/>
+   <Item id="additional_torque" 			file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3_v3.dds" file1=""/>
    <Item id="additional_torque2" 		file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3_v2.dds" file1=""/>
-   <Item id="add_speed_and_torque" 		file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3_v3.dds" file1=""/>
+   <Item id="add_speed_and_torque" 		file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3.dds" file1=""/>
 
    <Item id="additional_durability" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget1.dds" file1=""/>
    <Item id="additional_durability2" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget1_v2.dds" file1=""/>
    
-   <Item id="additional_stability" 		file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget4_v3.dds" file1=""/>
-   <Item id="add_stability_and_speed" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget4_v3.dds" file1=""/>
-   <Item id="add_torque_and_stability" file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3_v3.dds" file1=""/>
+   <Item id="additional_stability" 		file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget4.dds" file1=""/>
+   <Item id="add_stability_and_speed" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget4_v2.dds" file1=""/>
+   <Item id="add_torque_and_stability" file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget4_v3.dds" file1=""/>
 
 
    <Item id="TownSouth"			file1="data\if\ico\LocalMap\icn_town.dds" file=""/>

--- a/remaster/data/if/ico_hd/modelicons.xml
+++ b/remaster/data/if/ico_hd/modelicons.xml
@@ -133,18 +133,18 @@
    <Item id="cooling_system_guns" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_bul.dds" file1=""/>
    <Item id="cooling_system_energy" 		file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_enrg.dds" file1=""/>
    <Item id="cooling_system_explosion" 	file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_exp.dds" file1=""/>
-   <Item id="firing_rate_guns" 				file="data\if\ico_hd\InventoryDlg\Gadgets\gadget3_bul.dds" file1=""/>
-   <Item id="firing_rate_energy" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget3_enrg.dds" file1=""/>
+   <Item id="firing_rate_guns" 				file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_bul.dds" file1=""/>
+   <Item id="firing_rate_energy" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_enrg.dds" file1=""/>
    <Item id="grouping_angle_guns" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_bul.dds" file1=""/>
    <Item id="add_damage_guns" 				file="data\if\ico_hd\InventoryDlg\Gadgets\gadget4_bul.dds" file1=""/>
    <Item id="add_damage_energy" 				file="data\if\ico_hd\InventoryDlg\Gadgets\gadget4_enrg.dds" file1=""/>
    <Item id="add_damage_explosion" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget4_exp.dds" file1=""/>
-   <Item id="firing_range_guns"  			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget7_bul.dds" file1=""/>
+   <Item id="firing_range_guns"  			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_bul.dds" file1=""/>
    <Item id="cooling_system_guns2" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_v2_bul.dds" file1=""/>
    <Item id="cooling_system_energy2" 		file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_v2_enrg.dds" file1=""/>
    <Item id="cooling_system_explosion2" 	file="data\if\ico_hd\InventoryDlg\Gadgets\gadget1_v2_exp.dds" file1=""/>
-   <Item id="firing_rate_guns2" 			   file="data\if\ico_hd\InventoryDlg\Gadgets\gadget3_v2_bul.dds" file1=""/>
-   <Item id="firing_rate_energy2" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget3_v2_enrg.dds" file1=""/>
+   <Item id="firing_rate_guns2" 			   file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_v2_bul.dds" file1=""/>
+   <Item id="firing_rate_energy2" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_v2_enrg.dds" file1=""/>
    <Item id="grouping_angle_guns2" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget2_v2_bul.dds" file1=""/>
    <Item id="add_damage_guns2" 				file="data\if\ico_hd\InventoryDlg\Gadgets\gadget4_v2_bul.dds" file1=""/>
    <Item id="add_damage_energy2" 			file="data\if\ico_hd\InventoryDlg\Gadgets\gadget4_v2_enrg.dds" file1=""/>
@@ -164,16 +164,16 @@
    <Item id="additional_fuel_tank2" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget2_v2.dds" file1=""/>
    <Item id="additional_fuel_tank2_add_damage_guns" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget2_v3.dds" file1=""/>
    
-   <Item id="additional_torque" 			file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3_v3.dds" file1=""/>
+   <Item id="additional_torque" 			file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3.dds" file1=""/>
    <Item id="additional_torque2" 		file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3_v2.dds" file1=""/>
-   <Item id="add_speed_and_torque" 		file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3.dds" file1=""/>
+   <Item id="add_speed_and_torque" 		file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3_v3.dds" file1=""/>
 
    <Item id="additional_durability" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget1.dds" file1=""/>
    <Item id="additional_durability2" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget1_v2.dds" file1=""/>
    
-   <Item id="additional_stability" 		file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget4.dds" file1=""/>
-   <Item id="add_stability_and_speed" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget4_v2.dds" file1=""/>
-   <Item id="add_torque_and_stability" file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget4_v3.dds" file1=""/>
+   <Item id="additional_stability" 		file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget4_v3.dds" file1=""/>
+   <Item id="add_stability_and_speed" 	file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget4_v3.dds" file1=""/>
+   <Item id="add_torque_and_stability" file="data\if\ico_hd\InventoryDlg\Gadgets\sml_gadget3_v3.dds" file1=""/>
 
 
    <Item id="TownSouth"			file1="data\if\ico\LocalMap\icn_town.dds" file=""/>

--- a/remaster/hd_vehicle_models/data/gamedata/gameobjects/vehicleparts.xml
+++ b/remaster/hd_vehicle_models/data/gamedata/gameobjects/vehicleparts.xml
@@ -914,15 +914,15 @@ $Id: VehicleParts.xml,v 1.80 2005/11/28 07:43:57 anton Exp $
 			ModelFile			= "hunterCab01"
 			ResourceType			= "HUNTER_CABIN"
 			NodeScale			= "1 1 1"
-			Durability			= "350"
-			DurCoeffsForDamageTypes	= "20 10 -5"
+			Durability			= "150"
+			DurCoeffsForDamageTypes	= "20 0 -25"
 			VisibleInEncyclopedia = "false"
 			Mass				= "5.0"
 			EngineHighSound			= "ET_S_ENGINE_HUNTER_1_HIGH"
 			BlowEffect	= "ET_PS_VEH_PART_BLOW_SMALL_CAB"
 			MaxPower			= "120"
 			MaxTorque			= "80"
-			Price				= "5000"	
+			Price				= "10000"	
 			MaxSpeed			= "100.0"
 			LoadPoints			= "LP_GIANT01" >
 				<GroupsHealth
@@ -950,7 +950,7 @@ $Id: VehicleParts.xml,v 1.80 2005/11/28 07:43:57 anton Exp $
 			EngineHighSound		        = "ET_S_ENGINE_HUNTER_1_HIGH"
 			BlowEffect	= "ET_PS_VEH_PART_BLOW_SMALL_CAB"
 			MaxTorque			= "80"
-			Price				= "3000"	
+			Price				= "14000"	
 			MaxSpeed			= "100.0"
 			LoadPoints			= "LP_SML01 LP_BIG01" >
 				<GroupsHealth

--- a/remaster/hd_vehicle_models/data/gamedata/gameobjects/vehicleparts.xml
+++ b/remaster/hd_vehicle_models/data/gamedata/gameobjects/vehicleparts.xml
@@ -914,15 +914,15 @@ $Id: VehicleParts.xml,v 1.80 2005/11/28 07:43:57 anton Exp $
 			ModelFile			= "hunterCab01"
 			ResourceType			= "HUNTER_CABIN"
 			NodeScale			= "1 1 1"
-			Durability			= "150"
-			DurCoeffsForDamageTypes	= "20 0 -25"
+			Durability			= "350"
+			DurCoeffsForDamageTypes	= "20 10 -5"
 			VisibleInEncyclopedia = "false"
 			Mass				= "5.0"
 			EngineHighSound			= "ET_S_ENGINE_HUNTER_1_HIGH"
 			BlowEffect	= "ET_PS_VEH_PART_BLOW_SMALL_CAB"
 			MaxPower			= "120"
 			MaxTorque			= "80"
-			Price				= "10000"	
+			Price				= "5000"	
 			MaxSpeed			= "100.0"
 			LoadPoints			= "LP_GIANT01" >
 				<GroupsHealth
@@ -950,7 +950,7 @@ $Id: VehicleParts.xml,v 1.80 2005/11/28 07:43:57 anton Exp $
 			EngineHighSound		        = "ET_S_ENGINE_HUNTER_1_HIGH"
 			BlowEffect	= "ET_PS_VEH_PART_BLOW_SMALL_CAB"
 			MaxTorque			= "80"
-			Price				= "14000"	
+			Price				= "3000"	
 			MaxSpeed			= "100.0"
 			LoadPoints			= "LP_SML01 LP_BIG01" >
 				<GroupsHealth

--- a/remaster/hd_vehicle_models/data/gamedata/gameobjects/vehicleparts.xml
+++ b/remaster/hd_vehicle_models/data/gamedata/gameobjects/vehicleparts.xml
@@ -2921,7 +2921,7 @@ $Id: VehicleParts.xml,v 1.80 2005/11/28 07:43:57 anton Exp $
 			Mass				= "50.0"
 			LoadPoints			= "LP_BIG01" >
 			<RepositoryDescription
-				RepositorySize		= "8 9">
+				RepositorySize		= "4 6">
 				<Slot
 					Name		= "BASKET_BIG_GUN_0"
 					Pos		= "10 0"


### PR DESCRIPTION
Поправил неверно выставленные иконки гаджетов для комремастера. Компатч не проверял.

Кабины охотника:
Для первой восстановил оригинальные значения брони (150 вместо 350), сопротивлений (-10 вместо 0 для взрывов, -25 вместо -5 для энергетики) и стоимости (10к вместо 5к).
Для второй восстановил оригинальную стоимость (14к вместо 3к)
Хотя я могу согласиться, что вторая кабина охотника в оригинале слишком дорого стоит, но, во-первых, не в 4 же с лишним раза её уменьшать, а во-вторых, изменение стоимости кабин лишь одного автомобиля считаю неуместным в формате патча. 

Для 4 кузова бото-уралов проставил размер кузова 4х6, как у всех остальных бото-кузовов.