### PR TITLE
Fixed Hideout (r3m1) and Asgard (r1m3) entrance radius

### DIFF
--- a/patch/maps/r1m3/dynamicscene.xml
+++ b/patch/maps/r1m3/dynamicscene.xml
@@ -323,7 +323,7 @@
 			Name="Asgard_enter"
 			Belong="1011"
 			Prototype="genericLocation"
-			Pos="3600.624 289.100 6164.520"
+			Pos="3592.432 288.958 6157.910"
 			Rot="-0.011 -0.888 -0.014 0.460"
 			Radius="30.000"
 			LookingTimeOut="10.000" />

--- a/patch/maps/r3m1/dynamicscene.xml
+++ b/patch/maps/r3m1/dynamicscene.xml
@@ -761,9 +761,9 @@
 			Name="TheRazboynik_enter"
 			Belong="1063"
 			Prototype="genericLocation"
-			Pos="489.842 303.424 1703.576"
+			Pos="464.754 320.786 1774.458"
 			Rot="0.000 0.851 0.000 -0.526"
-			Radius="64.640" />
+			Radius="46.640" />
 
 		<Parts>
 			<AttackTeam


### PR DESCRIPTION
Title says itself.
Asgard's _enter location was too close to the gates.
Hideout's _enter location had an enormous radius so that player was able to enter town even if he was pretty far from the it.
Fixed it.