### PR TITLE
Breakable objects NodeScale fix

### DIFF
--- a/patch/maps/r1m2/dynamicscene.xml
+++ b/patch/maps/r1m2/dynamicscene.xml
@@ -48432,152 +48432,133 @@
 		Belong="-1"
 		Prototype="Breakable_Barrel1"
 		Pos="4862.243 64.000 3363.721"
-		Rot="0.000 -0.934 0.000 0.358"
-		NodeScale="0.890" />
+		Rot="0.000 -0.934 0.000 0.358" />
 
 	<Object
 		Name="barrel16080"
 		Belong="-1"
 		Prototype="Breakable_Barrel1"
 		Pos="4860.806 64.000 3363.042"
-		Rot="0.000 -0.968 0.000 0.250"
-		NodeScale="1.080" />
+		Rot="0.000 -0.968 0.000 0.250" />
 
 	<Object
 		Name="barrel16081"
 		Belong="-1"
 		Prototype="Breakable_Barrel1"
 		Pos="4861.761 64.000 3360.943"
-		Rot="0.000 0.035 0.000 0.999"
-		NodeScale="0.960" />
+		Rot="0.000 0.035 0.000 0.999" />
 
 	<Object
 		Name="barrel16082"
 		Belong="-1"
 		Prototype="Breakable_Barrel1"
 		Pos="4859.557 64.000 3361.984"
-		Rot="0.000 0.772 0.000 0.636"
-		NodeScale="1.190" />
+		Rot="0.000 0.772 0.000 0.636" />
 
 	<Object
 		Name="barrel26083"
 		Belong="-1"
 		Prototype="Breakable_Barrel2"
 		Pos="4870.174 64.000 3349.896"
-		Rot="0.000 0.026 0.000 1.000"
-		NodeScale="0.940" />
+		Rot="0.000 0.026 0.000 1.000" />
 
 	<Object
 		Name="barrel26084"
 		Belong="-1"
 		Prototype="Breakable_Barrel2"
 		Pos="4866.596 64.000 3350.634"
-		Rot="0.000 -0.676 0.000 0.737"
-		NodeScale="1.110" />
+		Rot="0.000 -0.676 0.000 0.737" />
 
 	<Object
 		Name="barrel26085"
 		Belong="-1"
 		Prototype="Breakable_Barrel2"
 		Pos="4867.313 64.000 3348.983"
-		Rot="0.000 -0.985 0.000 0.174"
-		NodeScale="1.070" />
+		Rot="0.000 -0.985 0.000 0.174" />
 
 	<Object
 		Name="barrel26086"
 		Belong="-1"
 		Prototype="Breakable_Barrel2"
 		Pos="4864.944 64.000 3351.650"
-		Rot="0.000 0.695 0.000 0.719"
-		NodeScale="1.070" />
+		Rot="0.000 0.695 0.000 0.719" />
 
 	<Object
 		Name="barrel36087"
 		Belong="-1"
 		Prototype="Breakable_Barrel3"
 		Pos="4870.040 64.000 3352.418"
-		Rot="0.000 0.993 0.000 0.122"
-		NodeScale="1.020" />
+		Rot="0.000 0.993 0.000 0.122" />
 
 	<Object
 		Name="barrel36088"
 		Belong="-1"
 		Prototype="Breakable_Barrel3"
 		Pos="4872.371 64.000 3353.641"
-		Rot="0.000 -0.982 0.000 0.191"
-		NodeScale="1.040" />
+		Rot="0.000 -0.982 0.000 0.191" />
 
 	<Object
 		Name="barrel36089"
 		Belong="-1"
 		Prototype="Breakable_Barrel3"
 		Pos="4868.229 64.000 3353.699"
-		Rot="0.000 -0.250 0.000 0.968"
-		NodeScale="0.850" />
+		Rot="0.000 -0.250 0.000 0.968" />
 
 	<Object
 		Name="barrel36090"
 		Belong="-1"
 		Prototype="Breakable_Barrel3"
 		Pos="4871.130 64.000 3353.844"
-		Rot="0.000 0.552 0.000 0.834"
-		NodeScale="1.140" />
+		Rot="0.000 0.552 0.000 0.834" />
 
 	<Object
 		Name="barrel26091"
 		Belong="-1"
 		Prototype="Breakable_Barrel2"
 		Pos="4805.309 65.314 3471.296"
-		Rot="0.000 0.745 0.000 0.668"
-		NodeScale="0.830" />
+		Rot="0.000 0.745 0.000 0.668" />
 
 	<Object
 		Name="barrel26092"
 		Belong="-1"
 		Prototype="Breakable_Barrel2"
 		Pos="4806.313 65.311 3466.627"
-		Rot="0.000 -1.000 0.000 0.002"
-		NodeScale="1.120" />
+		Rot="0.000 -1.000 0.000 0.002" />
 
 	<Object
 		Name="barrel26093"
 		Belong="-1"
 		Prototype="Breakable_Barrel2"
 		Pos="4803.120 65.304 3468.604"
-		Rot="0.000 0.767 0.000 0.641"
-		NodeScale="0.810" />
+		Rot="0.000 0.767 0.000 0.641" />
 
 	<Object
 		Name="barrel26094"
 		Belong="-1"
 		Prototype="Breakable_Barrel2"
 		Pos="4811.042 65.329 3466.753"
-		Rot="0.000 0.998 0.000 0.059"
-		NodeScale="0.900" />
+		Rot="0.000 0.998 0.000 0.059" />
 
 	<Object
 		Name="barrel16095"
 		Belong="-1"
 		Prototype="Breakable_Barrel1"
 		Pos="4808.430 65.317 3469.156"
-		Rot="0.000 -0.813 0.000 0.583"
-		NodeScale="0.810" />
+		Rot="0.000 -0.813 0.000 0.583" />
 
 	<Object
 		Name="barrel16096"
 		Belong="-1"
 		Prototype="Breakable_Barrel1"
 		Pos="4808.059 65.317 3468.723"
-		Rot="0.000 0.425 0.000 0.905"
-		NodeScale="1.030" />
+		Rot="0.000 0.425 0.000 0.905" />
 
 	<Object
 		Name="barrel16097"
 		Belong="-1"
 		Prototype="Breakable_Barrel1"
 		Pos="4806.848 65.313 3469.432"
-		Rot="0.000 0.624 0.000 0.781"
-		NodeScale="1.030" />
+		Rot="0.000 0.624 0.000 0.781" />
 
 	<Object
 		Name="stolb26098"
@@ -48714,56 +48695,49 @@
 		Belong="-1"
 		Prototype="Breakable_Poster1"
 		Pos="5075.486 91.176 3370.745"
-		Rot="0.000 0.850 0.000 0.527"
-		NodeScale="0.990" />
+		Rot="0.000 0.850 0.000 0.527" />
 
 	<Object
 		Name="deadtree36118"
 		Belong="-1"
 		Prototype="Breakable_DeadTree3"
 		Pos="5390.100 78.957 3425.232"
-		Rot="0.000 0.839 0.000 0.545"
-		NodeScale="1.140" />
+		Rot="0.000 0.839 0.000 0.545" />
 
 	<Object
 		Name="deadtree46119"
 		Belong="-1"
 		Prototype="Breakable_DeadTree4"
 		Pos="5455.875 76.903 3470.259"
-		Rot="0.000 -0.814 0.000 0.581"
-		NodeScale="1.110" />
+		Rot="0.000 -0.814 0.000 0.581" />
 
 	<Object
 		Name="deadtree46120"
 		Belong="-1"
 		Prototype="Breakable_DeadTree4"
 		Pos="5547.337 64.118 3741.837"
-		Rot="0.000 0.857 0.000 0.515"
-		NodeScale="0.920" />
+		Rot="0.000 0.857 0.000 0.515" />
 
 	<Object
 		Name="deadtree16121"
 		Belong="-1"
 		Prototype="Breakable_DeadTree1"
 		Pos="5163.629 69.900 3351.200"
-		Rot="0.000 0.682 0.000 0.731"
-		NodeScale="1.100" />
+		Rot="0.000 0.682 0.000 0.731" />
 
 	<Object
 		Name="poddon6122"
 		Belong="-1"
 		Prototype="poddon"
 		Pos="3795.359 116.000 1788.460"
-		Rot="0.000 -0.044 0.000 0.999"
-		NodeScale="0.820" />
+		Rot="0.000 -0.044 0.000 0.999" />
 
 	<Object
 		Name="factory_box6123"
 		Belong="-1"
 		Prototype="factory_box"
 		Pos="3795.603 116.000 1788.408"
-		Rot="0.000 -0.920 0.000 0.391"
-		NodeScale="0.850" />
+		Rot="0.000 -0.920 0.000 0.391" />
 
 	<Object
 		Belong="-1"

--- a/patch/maps/r1m2/dynamicscene.xml
+++ b/patch/maps/r1m2/dynamicscene.xml
@@ -43645,13 +43645,13 @@
 		Pos="4803.305 110.348 1115.352"
 		Rot="0.000 -0.968 0.000 0.250" />
 
+	<!--1.885-->
 	<Object
 		Name="road_sign15349"
 		Belong="-1"
 		Prototype="road_sign1"
 		Pos="5498.259 69.317 3898.010"
-		Rot="0.000 -0.938 0.000 0.348"
-		NodeScale="1.885" />
+		Rot="0.000 -0.938 0.000 0.348" />
 
 	<Object
 		Name="traffic_lights35350"
@@ -48385,12 +48385,13 @@
 		Pos="5139.346 70.188 2318.734"
 		Rot="0.000 -0.713 0.000 0.701" />
 
+	<!--Check this also, it was 1.546 bruh-->
 	<Object
 		Name="billboard26073"
 		Belong="-1"
 		Prototype="Breakable_Poster2"
-		Pos="5248.839 68.410 2100.550"
-		NodeScale="1.546" />
+		Pos="5248.839 68.410 2100.550" />
+	<!--Whoopsie-doopsie-->
 
 	<Object
 		Name="billboard36074"

--- a/patch/maps/r1m3/dynamicscene.xml
+++ b/patch/maps/r1m3/dynamicscene.xml
@@ -61756,8 +61756,7 @@
 		Belong="-1"
 		Prototype="Breakable_Poster3"
 		Pos="3845.883 235.349 786.369"
-		Rot="0.000 -0.942 0.000 0.336"
-		NodeScale="1.126" />
+		Rot="0.000 -0.942 0.000 0.336" />
 
 	<Object
 		Name="lamppost39285"

--- a/patch/maps/r1m4/dynamicscene.xml
+++ b/patch/maps/r1m4/dynamicscene.xml
@@ -29524,13 +29524,13 @@
 		Prototype="road_sign4"
 		Pos="2796.365 247.329 1904.333" />
 
+	<!--2.297-->
 	<Object
 		Name="road_sign13480"
 		Belong="-1"
 		Prototype="road_sign1"
 		Pos="2759.270 247.487 1911.040"
-		Rot="0.000 0.993 0.000 0.120"
-		NodeScale="2.297" />
+		Rot="0.000 0.993 0.000 0.120"/>
 
 	<Object
 		Name="lamppost13481"

--- a/patch/maps/r2m2/dynamicscene.xml
+++ b/patch/maps/r2m2/dynamicscene.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="windows-1251" standalone="yes" ?>
 <DynamicScene
-	LastId="1679">
+	LastId="1682">
 	<TargetNamesForDestroy
 		Names="u1 u2 u3 u4 u5 u6 u7 u8 u9" />
 
@@ -1516,7 +1516,7 @@
 			Name="staticAutoGun017"
 			Belong="1043"
 			Prototype="staticAutoGun01"
-			Pos="2189.585 278.350 2076.871">
+			Pos="2189.585 278.222 2076.871">
 			<Parts />
 		</Object>
 
@@ -3245,7 +3245,7 @@
 			Name="js_barricade133_Child5"
 			Belong="1002"
 			Prototype="sack_dot2_kord"
-			Pos="1737.650 257.697 3055.555"
+			Pos="1737.650 257.643 3055.555"
 			Rot="0.000 -0.906 0.000 0.423">
 			<Parts />
 		</Object>
@@ -3665,193 +3665,6 @@
 			<Parts />
 		</Object>
 	</Object>
-	
-<!-- Оригинальные ящики
-
-	<Object
-		Name="someChest60"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="3428.136 330.085 3934.201">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="fuel" />
-
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="kpvt01" />
-	</Object>
-
-	<Object
-		Name="someChest86"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="3495.313 330.390 3897.704">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="fuel" />
-
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="machinery" />
-
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="pkt01" />
-	</Object>
-
-	<Object
-		Name="someChest53"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="268.560 321.000 3937.622">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="fuel" />
-
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="fagot01" />
-	</Object>
-
-	<Object
-		Name="someChest80"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="268.917 321.000 3896.978">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="pkt01" />
-	</Object>
-
-	<Object
-		Name="someChest48"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="335.536 321.000 3903.331">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="specter01" />
-
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="vulcan01" />
-	</Object>
-
-	<Object
-		Name="someChest63"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="755.634 261.115 3298.566">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="hornet01" />
-	</Object>
-
-	<Object
-		Name="someChest6etert0"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="892.778 251.147 2712.201">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="vulcan01" />
-	</Object>
-
-	<Object
-		Name="someChest9eeee9"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="1788.491 325.688 3775.495">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="machinery" />
-
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="specter01" />
-
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="specter01" />
-	</Object>
-
-	<Object
-		Name="someChest99"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="2415.842 261.000 2855.342">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="scrap_metal" />
-
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="scrap_metal" />
-
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="vulcan01" />
-	</Object>
-
-	<Object
-		Name="someChest70"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="1717.426 246.771 1727.592">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="kord01" />
-	</Object>
-
-	<Object
-		Name="someChest25"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="1897.972 241.969 1426.772">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="pkt01" />
-	</Object>
-
-	<Object
-		Name="someChest43"
-		Belong="1001"
-		Prototype="someChest"
-		Pos="2723.096 303.005 2738.789">
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="fuel" />
-
-		<Object
-			Flags="16"
-			Belong="1001"
-			Prototype="specter01" />
-	</Object>
-	-->
-	
-	<!-- Лутбоксы -->
 
 	<Object
 		Flags="21"
@@ -3967,21 +3780,21 @@
 		Name="wood_fence22"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3332.143 279.828 1465.545"
+		Pos="3332.143 279.774 1465.545"
 		Rot="0.000 0.126 0.000 0.992" />
 
 	<Object
 		Name="wood_fence13"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3342.913 279.993 1462.219"
+		Pos="3342.913 279.961 1462.219"
 		Rot="0.000 0.176 0.000 0.984" />
 
 	<Object
 		Name="wood_fence24"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3359.862 279.844 1454.734"
+		Pos="3359.862 279.791 1454.734"
 		Rot="0.000 0.202 0.000 0.979" />
 
 	<Object
@@ -3995,76 +3808,76 @@
 		Name="wood_fence26"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3283.365 280.317 1466.171"
+		Pos="3283.365 280.284 1466.171"
 		Rot="0.000 0.111 0.000 0.994" />
 
 	<Object
 		Name="wood_fence17"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3272.759 280.302 1467.249" />
+		Pos="3272.759 280.248 1467.249" />
 
 	<Object
 		Name="wood_fence28"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3262.508 280.189 1466.951"
+		Pos="3262.508 280.136 1466.951"
 		Rot="0.000 -0.037 0.000 0.999" />
 
 	<Object
 		Name="wood_fence19"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3247.044 280.117 1463.252"
+		Pos="3247.044 280.063 1463.252"
 		Rot="0.000 -0.133 0.000 0.991" />
 
 	<Object
 		Name="wood_fence210"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3237.589 280.082 1459.196"
+		Pos="3237.589 280.028 1459.196"
 		Rot="0.000 -0.278 0.000 0.961" />
 
 	<Object
 		Name="wood_fence111"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3193.310 278.959 1290.535"
+		Pos="3193.310 278.905 1290.535"
 		Rot="0.000 -0.741 0.000 0.671" />
 
 	<Object
 		Name="wood_fence212"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3193.244 278.866 1301.947"
+		Pos="3193.244 278.813 1301.947"
 		Rot="0.000 -0.685 0.000 0.729" />
 
 	<Object
 		Name="wood_fence113"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3193.218 278.946 1312.788"
+		Pos="3193.218 278.892 1312.788"
 		Rot="0.000 -0.713 0.000 0.701" />
 
 	<Object
 		Name="wood_fence214"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3192.854 279.056 1323.497"
+		Pos="3192.854 279.003 1323.497"
 		Rot="0.000 -0.717 0.000 0.697" />
 
 	<Object
 		Name="wood_fence115"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3192.484 279.203 1334.460"
+		Pos="3192.484 279.149 1334.460"
 		Rot="0.000 -0.705 0.000 0.709" />
 
 	<Object
 		Name="wood_fence216"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3192.502 279.342 1345.094"
+		Pos="3192.502 279.306 1345.094"
 		Rot="0.000 -0.685 0.000 0.729" />
 
 	<Object
@@ -4078,7 +3891,7 @@
 		Name="wood_fence218"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3192.630 279.644 1365.855"
+		Pos="3192.630 279.593 1365.855"
 		Rot="0.000 -0.685 0.000 0.729" />
 
 	<Object
@@ -4099,91 +3912,91 @@
 		Name="wood_fence121"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3424.301 279.568 1181.446"
+		Pos="3424.301 279.514 1181.446"
 		Rot="0.000 0.795 0.000 0.607" />
 
 	<Object
 		Name="wood_fence222"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3429.801 279.451 1199.155"
+		Pos="3429.801 279.398 1199.155"
 		Rot="0.000 0.796 0.000 0.605" />
 
 	<Object
 		Name="wood_fence123"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3432.888 279.467 1208.841"
+		Pos="3432.888 279.414 1208.841"
 		Rot="0.000 0.813 0.000 0.582" />
 
 	<Object
 		Name="wood_fence224"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3319.339 279.431 1118.994"
+		Pos="3319.339 279.377 1118.994"
 		Rot="0.000 -0.996 0.000 0.085" />
 
 	<Object
 		Name="wood_fence125"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3309.130 279.462 1121.494"
+		Pos="3309.130 279.424 1121.494"
 		Rot="0.000 -0.988 0.000 0.152" />
 
 	<Object
 		Name="wood_fence226"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3298.839 279.778 1124.308"
+		Pos="3298.839 279.724 1124.308"
 		Rot="0.000 -0.992 0.000 0.126" />
 
 	<Object
 		Name="wood_fence127"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3285.484 279.568 1129.391"
+		Pos="3285.484 279.514 1129.391"
 		Rot="0.000 -0.979 0.000 0.206" />
 
 	<Object
 		Name="wood_fence228"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3227.818 279.448 1189.906"
+		Pos="3227.818 279.401 1189.906"
 		Rot="0.000 -0.879 0.000 0.477" />
 
 	<Object
 		Name="wood_fence129"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3233.594 279.376 1181.139"
+		Pos="3233.594 279.322 1181.139"
 		Rot="0.000 -0.889 0.000 0.458" />
 
 	<Object
 		Name="wood_fence230"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3438.987 279.633 1351.891"
+		Pos="3438.987 279.579 1351.891"
 		Rot="0.000 0.621 0.000 0.784" />
 
 	<Object
 		Name="wood_fence131"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3435.900 279.670 1361.918"
+		Pos="3435.900 279.616 1361.918"
 		Rot="0.000 0.561 0.000 0.828" />
 
 	<Object
 		Name="wood_fence232"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3377.209 273.283 1333.726"
+		Pos="3377.209 273.243 1333.726"
 		Rot="0.000 -1.000 0.000 0.015" />
 
 	<Object
 		Name="wood_fence133"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3383.080 272.853 1339.280"
+		Pos="3383.080 272.799 1339.280"
 		Rot="0.000 0.679 0.000 0.734" />
 
 	<Object
@@ -4197,7 +4010,7 @@
 		Name="wood_fence135"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3301.645 276.698 1319.894"
+		Pos="3301.645 276.687 1319.894"
 		Rot="0.000 -0.718 0.000 0.696" />
 
 	<Object
@@ -4210,42 +4023,42 @@
 		Name="wood_fence137"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3359.580 270.230 1161.171"
+		Pos="3359.580 270.177 1161.171"
 		Rot="0.000 0.959 0.000 0.282" />
 
 	<Object
 		Name="wood_fence238"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3367.805 269.761 1168.030"
+		Pos="3367.805 269.707 1168.030"
 		Rot="0.000 0.914 0.000 0.407" />
 
 	<Object
 		Name="wood_fence139"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3373.590 269.512 1176.464"
+		Pos="3373.590 269.458 1176.464"
 		Rot="0.000 0.857 0.000 0.515" />
 
 	<Object
 		Name="wood_fence240"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3377.971 269.236 1186.013"
+		Pos="3377.971 269.182 1186.013"
 		Rot="0.000 0.838 0.000 0.546" />
 
 	<Object
 		Name="wood_fence141"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3238.391 268.620 1241.684"
+		Pos="3238.391 268.592 1241.684"
 		Rot="0.000 0.595 0.000 0.804" />
 
 	<Object
 		Name="wood_fence242"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3241.884 268.884 1231.683"
+		Pos="3241.884 268.831 1231.683"
 		Rot="0.000 0.561 0.000 0.828" />
 
 	<Object
@@ -4259,62 +4072,62 @@
 		Name="wood_fence244"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3377.522 273.002 1317.536" />
+		Pos="3377.522 272.976 1317.536" />
 
 	<Object
 		Name="wood_fence145"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3400.724 269.623 1283.464"
+		Pos="3400.724 269.570 1283.464"
 		Rot="0.000 -0.699 0.000 0.715" />
 
 	<Object
 		Name="wood_fence246"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3401.436 270.416 1293.686"
+		Pos="3401.436 270.363 1293.686"
 		Rot="0.000 -0.718 0.000 0.696" />
 
 	<Object
 		Name="wood_fence147"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3371.207 272.604 1398.020"
+		Pos="3371.207 272.550 1398.020"
 		Rot="0.000 -0.912 0.000 0.411" />
 
 	<Object
 		Name="wood_fence248"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3363.293 272.687 1405.633"
+		Pos="3363.293 272.661 1405.633"
 		Rot="0.000 -0.949 0.000 0.315" />
 
 	<Object
 		Name="wood_fence149"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3259.946 273.287 1397.820"
+		Pos="3259.946 273.233 1397.820"
 		Rot="0.000 -0.152 0.000 0.988" />
 
 	<Object
 		Name="wood_fence250"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3250.781 272.547 1392.329"
+		Pos="3250.781 272.494 1392.329"
 		Rot="0.000 -0.369 0.000 0.930" />
 
 	<Object
 		Name="wood_fence151"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
-		Pos="3244.109 272.410 1383.642"
+		Pos="3244.109 272.357 1383.642"
 		Rot="0.000 -0.561 0.000 0.828" />
 
 	<Object
 		Name="wood_fence252"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="3367.023 274.429 1318.138" />
+		Pos="3367.023 274.427 1318.138" />
 
 	<Object
 		Name="arena_barricade1374"
@@ -4392,76 +4205,76 @@
 		Name="arena_barricade1386"
 		Belong="-1"
 		Prototype="arena_barricade13"
-		Pos="3142.165 279.913 1354.957" />
+		Pos="3142.165 279.870 1354.957" />
 
 	<Object
 		Name="wood_fence287"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1351.115 236.000 1670.368"
-		Rot="0.000 0.698 0.000 0.716" />
+		Pos="1349.254 236.000 1630.955"
+		Rot="-0.003 0.718 -0.003 0.696" />
 
 	<Object
 		Name="wood_fence288"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1351.476 236.000 1654.265"
-		Rot="0.000 0.698 0.000 0.716" />
+		Pos="1348.872 236.000 1619.731"
+		Rot="-0.004 0.717 -0.005 0.698" />
 
 	<Object
 		Name="wood_fence289"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1351.075 236.000 1639.341"
-		Rot="0.000 0.698 0.000 0.716" />
+		Pos="1348.849 236.000 1608.751"
+		Rot="0.000 0.701 0.000 0.713" />
 
 	<Object
 		Name="wood_fence290"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1351.098 236.000 1622.252"
-		Rot="0.000 0.698 0.000 0.716" />
+		Pos="1348.678 236.000 1597.609"
+		Rot="-0.003 0.721 -0.003 0.693" />
 
 	<Object
 		Name="wood_fence291"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1349.946 236.000 1604.994"
-		Rot="0.000 0.698 0.000 0.716" />
+		Pos="1347.870 236.000 1586.009"
+		Rot="-0.000 0.712 0.000 0.702" />
 
 	<Object
 		Name="wood_fence292"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1348.841 236.000 1586.342"
-		Rot="0.000 0.698 0.000 0.716" />
+		Pos="1347.592 236.021 1575.015"
+		Rot="0.000 0.715 0.000 0.699" />
 
 	<Object
 		Name="wood_fence293"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1347.771 236.174 1567.586"
-		Rot="0.000 0.698 0.000 0.716" />
+		Pos="1347.283 236.174 1563.206"
+		Rot="0.003 0.707 0.003 0.707" />
 
 	<Object
 		Name="wood_fence294"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1352.767 236.011 1682.398"
-		Rot="0.000 0.820 0.000 0.572" />
+		Pos="1349.282 236.000 1642.073"
+		Rot="0.000 0.713 0.000 0.701" />
 
 	<Object
 		Name="wood_fence295"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1455.652 251.018 1676.158"
+		Pos="1449.827 251.024 1674.927"
 		Rot="0.000 -1.000 0.000 0.000" />
 
 	<Object
 		Name="wood_fence296"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1438.808 251.055 1675.584"
+		Pos="1438.493 251.067 1675.033"
 		Rot="0.000 -1.000 0.000 0.000" />
 
 	<Object
@@ -4475,36 +4288,36 @@
 		Name="wood_fence298"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1431.158 250.979 1656.580"
+		Pos="1431.355 250.980 1657.662"
 		Rot="0.000 -0.687 0.000 0.727" />
 
 	<Object
 		Name="wood_fence299"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1430.421 250.915 1644.511"
+		Pos="1430.617 250.920 1646.682"
 		Rot="0.000 -0.687 0.000 0.727" />
 
 	<Object
 		Name="wood_fence2100"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1430.137 251.002 1631.894"
-		Rot="0.000 -0.687 0.000 0.727" />
+		Pos="1429.867 250.912 1635.700"
+		Rot="0.000 -0.696 0.000 0.718" />
 
 	<Object
 		Name="wood_fence2101"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1429.618 251.093 1619.734"
-		Rot="0.000 -0.687 0.000 0.727" />
+		Pos="1429.596 251.018 1623.902"
+		Rot="0.000 -0.695 0.000 0.719" />
 
 	<Object
 		Name="wood_fence2102"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1429.022 251.177 1597.113"
-		Rot="0.000 -0.724 0.000 0.690" />
+		Pos="1428.604 251.109 1600.416"
+		Rot="0.002 -0.707 -0.001 0.707" />
 
 	<Object
 		Name="wood_fence2103"
@@ -4560,35 +4373,35 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2071.233 253.200 2123.887"
-		Rot="0.000 0.896 0.000 0.445" />
+		Rot="-0.094 0.891 -0.046 0.442" />
 
 	<Object
 		Name="wood_fence2113"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2079.128 255.676 2134.082"
-		Rot="0.000 0.890 0.000 0.456" />
+		Rot="-0.086 0.899 -0.047 0.426" />
 
 	<Object
 		Name="wood_fence2114"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2085.462 257.426 2143.625"
-		Rot="0.000 0.863 0.000 0.505" />
+		Rot="-0.066 0.893 -0.043 0.442" />
 
 	<Object
 		Name="wood_fence2115"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2080.999 258.217 2150.013"
-		Rot="0.000 0.124 0.000 0.992" />
+		Rot="-0.004 0.139 -0.028 0.990" />
 
 	<Object
 		Name="wood_fence2116"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2176.311 259.200 2248.920"
-		Rot="0.000 0.948 0.000 0.319" />
+		Rot="0.006 0.973 0.001 0.229" />
 
 	<Object
 		Name="wood_fence2117"
@@ -4630,7 +4443,7 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2185.694 258.617 2257.446"
-		Rot="0.000 0.881 0.000 0.473" />
+		Rot="0.023 0.887 0.013 0.461" />
 
 	<Object
 		Name="wood_fence2123"
@@ -5015,7 +4828,7 @@
 		Name="poddon171"
 		Belong="-1"
 		Prototype="poddon"
-		Pos="2982.556 267.743 2113.019" />
+		Pos="2982.556 267.735 2113.019" />
 
 	<Object
 		Name="factory_box172"
@@ -5532,14 +5345,14 @@
 		Name="wood_fence2236"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="773.883 247.612 2428.743"
+		Pos="773.883 247.558 2428.743"
 		Rot="0.000 -0.381 0.000 0.925" />
 
 	<Object
 		Name="wood_fence2237"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="768.864 246.930 2420.485"
+		Pos="768.864 246.876 2420.485"
 		Rot="0.000 -0.602 0.000 0.799" />
 
 	<Object
@@ -5560,14 +5373,14 @@
 		Name="wood_fence2240"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="786.841 248.112 2404.721"
+		Pos="786.841 248.059 2404.721"
 		Rot="0.000 0.994 0.000 0.111" />
 
 	<Object
 		Name="wood_fence2241"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="793.954 247.999 2410.287"
+		Pos="793.954 247.945 2410.287"
 		Rot="0.000 0.861 0.000 0.509" />
 
 	<Object
@@ -5660,33 +5473,29 @@
 		Name="wood_fence2253"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1429.034 251.171 1608.260"
-		Rot="0.000 -0.687 0.000 0.727"
-		 />
+		Pos="1429.022 251.084 1612.127"
+		Rot="0.000 -0.703 0.000 0.712" />
 
 	<Object
 		Name="wood_fence2254"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1429.483 251.184 1586.008"
-		Rot="0.000 -0.724 0.000 0.690"
-		 />
+		Pos="1428.854 251.115 1589.193"
+		Rot="0.000 -0.721 0.000 0.693" />
 
 	<Object
 		Name="wood_fence2255"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1430.641 251.200 1575.140"
-		Rot="0.000 -0.749 0.000 0.663"
-		 />
+		Pos="1429.223 251.107 1578.023"
+		Rot="-0.007 -0.724 0.006 0.690" />
 
 	<Object
 		Name="wood_fence2256"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1432.073 251.222 1564.097"
-		Rot="0.000 -0.749 0.000 0.663"
-		 />
+		Pos="1429.588 251.090 1566.969"
+		Rot="0.000 -0.730 0.000 0.684" />
 
 	<Object
 		Name="wood_fence2257"
@@ -5749,21 +5558,21 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="805.502 247.932 2465.438"
-		Rot="0.000 0.906 0.000 0.423" />
+		Rot="0.000 0.927 0.000 0.375" />
 
 	<Object
 		Name="wood_fence2266"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="797.177 247.965 2461.427"
-		Rot="0.000 0.999 0.000 0.048" />
+		Rot="0.000 0.997 0.000 0.072" />
 
 	<Object
 		Name="wood_fence2267"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="787.176 248.010 2461.502"
-		Rot="0.000 -1.000 0.000 0.031" />
+		Pos="787.068 248.011 2461.172"
+		Rot="0.000 -0.998 0.000 0.057" />
 
 	<Object
 		Name="wood_fence2268"
@@ -5797,14 +5606,14 @@
 		Name="wood_fence2272"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="749.336 248.215 2421.159"
+		Pos="749.336 248.162 2421.159"
 		Rot="0.000 0.774 0.000 0.633" />
 
 	<Object
 		Name="wood_fence2273"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="748.581 248.117 2411.231"
+		Pos="748.581 248.063 2411.231"
 		Rot="0.000 0.676 0.000 0.737" />
 
 	<Object
@@ -5825,7 +5634,7 @@
 		Name="wood_fence2276"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="769.462 248.012 2385.752"
+		Pos="769.462 247.958 2385.752"
 		Rot="0.000 0.148 0.000 0.989" />
 
 	<Object
@@ -5846,7 +5655,7 @@
 		Name="wood_fence2279"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="782.266 248.030 2382.666"
+		Pos="782.266 247.976 2382.666"
 		Rot="0.000 -0.013 0.000 1.000" />
 
 	<Object
@@ -5881,7 +5690,7 @@
 		Name="wood_fence2284"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="804.384 248.098 2397.059"
+		Pos="804.384 248.044 2397.059"
 		Rot="0.000 -0.664 0.000 0.747" />
 
 	<Object
@@ -5896,7 +5705,7 @@
 		Name="wood_fence2286"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="807.362 248.206 2406.870"
+		Pos="807.362 248.152 2406.870"
 		Rot="0.000 -0.545 0.000 0.839" />
 
 	<Object
@@ -6030,8 +5839,8 @@
 		Name="wood_fence2305"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="2316.613 251.790 1355.940"
-		Rot="0.000 0.646 0.000 0.763" />
+		Pos="2316.988 251.790 1355.893"
+		Rot="0.000 0.676 0.000 0.737" />
 
 	<Object
 		Name="wood_fence2306"
@@ -6072,14 +5881,14 @@
 		Name="wood_fence2311"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="2306.405 256.536 1454.277"
+		Pos="2306.530 256.502 1453.081"
 		Rot="0.000 0.677 0.000 0.736" />
 
 	<Object
 		Name="wood_fence2312"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="2307.172 256.394 1442.909"
+		Pos="2307.220 256.371 1442.151"
 		Rot="0.000 0.677 0.000 0.736" />
 
 	<Object
@@ -6093,8 +5902,8 @@
 		Name="wood_fence2314"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="2307.923 255.753 1420.314"
-		Rot="0.000 0.646 0.000 0.763" />
+		Pos="2308.174 255.716 1420.553"
+		Rot="0.000 0.695 0.000 0.719" />
 
 	<Object
 		Name="wood_fence2315"
@@ -6181,8 +5990,7 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2353.960 251.009 1349.094"
-		Rot="0.000 0.995 0.000 0.104"
-		 />
+		Rot="0.000 0.995 0.000 0.104" />
 
 	<Object
 		Name="wood_fence2327"
@@ -6224,8 +6032,7 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2299.975 266.709 1504.725"
-		Rot="0.000 0.936 0.000 0.352"
-		 />
+		Rot="0.000 0.936 0.000 0.352" />
 
 	<Object
 		Name="wood_fence2333"
@@ -6301,28 +6108,28 @@
 		Name="wood_fence2343"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="2364.645 250.915 1351.711"
-		Rot="0.000 0.991 0.000 0.137" />
+		Pos="2365.038 250.913 1351.293"
+		Rot="0.000 0.995 0.000 0.100" />
 
 	<Object
 		Name="wood_fence2344"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="2375.118 250.994 1354.620"
-		Rot="0.000 0.991 0.000 0.137" />
+		Pos="2376.520 251.015 1353.238"
+		Rot="-0.006 0.996 -0.001 0.087" />
 
 	<Object
 		Name="wood_fence2345"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="2385.920 251.321 1357.684"
-		Rot="0.000 0.991 0.000 0.137" />
+		Pos="2387.774 251.306 1355.107"
+		Rot="0.000 0.996 0.000 0.087" />
 
 	<Object
 		Name="wood_fence2346"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="2258.421 236.030 2564.188"
+		Pos="2258.421 235.976 2564.188"
 		Rot="0.000 -0.541 0.000 0.841"
 		NodeScale="1.285" />
 
@@ -6338,7 +6145,7 @@
 		Name="wood_fence2348"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="2253.047 235.983 2552.806"
+		Pos="2253.047 235.959 2552.806"
 		Rot="0.000 -0.532 0.000 0.847"
 		NodeScale="1.285" />
 
@@ -6362,7 +6169,7 @@
 		Name="wood_fence2351"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="2267.801 236.021 2596.405"
+		Pos="2267.801 235.967 2596.405"
 		Rot="0.000 -0.649 0.000 0.760"
 		NodeScale="1.285" />
 
@@ -6722,8 +6529,8 @@
 		Name="wood_fence2397"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1481.845 292.000 2417.042"
-		Rot="0.000 0.749 0.000 0.663"
+		Pos="1482.109 292.000 2415.717"
+		Rot="0.000 0.701 0.000 0.713"
 		NodeScale="1.285" />
 
 	<Object
@@ -6746,7 +6553,7 @@
 		Name="wood_fence2400"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1502.811 292.000 2438.955"
+		Pos="1504.062 292.000 2439.027"
 		Rot="0.000 0.998 0.000 0.070"
 		NodeScale="1.285" />
 
@@ -6778,15 +6585,15 @@
 		Name="wood_fence2404"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1517.922 292.237 2285.090"
-		Rot="0.000 0.593 0.000 0.805"
+		Pos="1518.161 292.095 2288.885"
+		Rot="0.000 0.639 0.000 0.769"
 		NodeScale="1.285" />
 
 	<Object
 		Name="wood_fence2405"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1523.354 292.569 2274.118"
+		Pos="1523.070 292.569 2275.193"
 		Rot="0.000 0.496 0.000 0.868"
 		NodeScale="1.285" />
 
@@ -6802,8 +6609,8 @@
 		Name="wood_fence2407"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1539.214 292.710 2255.308"
-		Rot="0.000 0.240 0.000 0.971"
+		Pos="1540.187 292.752 2254.195"
+		Rot="0.000 0.332 0.000 0.943"
 		NodeScale="1.285" />
 
 	<Object
@@ -6818,7 +6625,7 @@
 		Name="wood_fence2409"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1528.774 291.994 2473.217"
+		Pos="1528.833 291.994 2474.461"
 		Rot="0.000 0.698 0.000 0.716"
 		NodeScale="1.285" />
 
@@ -6826,7 +6633,7 @@
 		Name="wood_fence2410"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1528.435 291.998 2485.740"
+		Pos="1528.628 291.997 2487.642"
 		Rot="0.000 0.698 0.000 0.716"
 		NodeScale="1.285" />
 
@@ -6834,7 +6641,7 @@
 		Name="wood_fence2411"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1527.643 292.000 2499.326"
+		Pos="1527.958 292.000 2500.710"
 		Rot="0.000 0.671 0.000 0.742"
 		NodeScale="1.285" />
 
@@ -6842,7 +6649,7 @@
 		Name="wood_fence2412"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1524.826 292.028 2523.743"
+		Pos="1525.111 292.032 2524.285"
 		Rot="0.000 0.658 0.000 0.753"
 		NodeScale="1.285" />
 
@@ -6866,31 +6673,31 @@
 		Name="wood_fence2415"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1524.002 292.010 2577.744"
-		Rot="0.000 0.785 0.000 0.619"
+		Pos="1523.032 292.008 2578.358"
+		Rot="0.002 0.713 0.001 0.701"
 		NodeScale="1.285" />
 
 	<Object
 		Name="wood_fence2416"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1526.156 292.035 2600.305"
-		Rot="0.000 0.696 0.000 0.718"
+		Pos="1525.778 292.035 2598.992"
+		Rot="0.000 0.734 0.000 0.679"
 		NodeScale="1.285" />
 
 	<Object
 		Name="wood_fence2417"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1527.212 292.113 2612.809"
-		Rot="0.000 0.763 0.000 0.646"
+		Pos="1527.291 292.061 2612.224"
+		Rot="-0.002 0.759 -0.001 0.651"
 		NodeScale="1.285" />
 
 	<Object
 		Name="wood_fence2418"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1529.927 292.274 2625.036"
+		Pos="1529.953 292.221 2624.955"
 		Rot="0.000 0.792 0.000 0.611"
 		NodeScale="1.285" />
 
@@ -6898,24 +6705,24 @@
 		Name="wood_fence2419"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1534.624 292.346 2636.478"
-		Rot="0.000 0.870 0.000 0.492"
+		Pos="1534.334 292.294 2636.771"
+		Rot="0.000 0.858 0.000 0.513"
 		NodeScale="1.285" />
 
 	<Object
 		Name="wood_fence2420"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1541.694 292.374 2646.637"
-		Rot="0.000 0.899 0.000 0.438"
+		Pos="1540.869 292.325 2648.141"
+		Rot="0.000 0.872 0.000 0.490"
 		NodeScale="1.285" />
 
 	<Object
 		Name="wood_fence2421"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1550.627 292.377 2654.883"
-		Rot="0.000 0.955 0.000 0.297"
+		Pos="1550.600 292.301 2656.730"
+		Rot="0.000 0.974 0.000 0.225"
 		NodeScale="1.285" />
 
 	<Object
@@ -7402,7 +7209,7 @@
 		Name="lamppost3482"
 		Belong="-1"
 		Prototype="lamppost3"
-		Pos="2503.786 352.874 1991.443"
+		Pos="2503.786 352.881 1991.443"
 		Rot="0.000 0.530 0.000 0.848"
 		NodeScale="3.694" />
 
@@ -7505,7 +7312,7 @@
 		Name="wood_fence2496"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
-		Pos="1523.683 292.018 2537.143"
+		Pos="1523.876 292.018 2537.618"
 		Rot="0.000 0.690 0.000 0.724"
 		NodeScale="1.285" />
 
@@ -8020,7 +7827,7 @@
 		Name="dub3_r2561"
 		Belong="-1"
 		Prototype="Breakable_dub3_r2"
-		Pos="1900.877 353.000 3294.703"
+		Pos="1900.877 376.939 3294.703"
 		Rot="0.000 -0.523 0.000 0.853"
 		NodeScale="1.180" />
 
@@ -9040,7 +8847,7 @@
 		Name="r2_deadtree4690"
 		Belong="-1"
 		Prototype="Breakable_r2_deadtree4"
-		Pos="1348.573 236.009 1681.840"
+		Pos="1337.607 236.000 1687.034"
 		Rot="0.000 0.988 0.000 0.156"
 		NodeScale="1.150" />
 
@@ -13572,7 +13379,7 @@
 		Name="r2_deadtree41263"
 		Belong="-1"
 		Prototype="Breakable_r2_deadtree4"
-		Pos="3387.620 332.336 3467.869"
+		Pos="3387.620 330.300 3467.869"
 		Rot="0.000 0.367 0.000 0.930"
 		NodeScale="0.940" />
 
@@ -13620,7 +13427,7 @@
 		Name="r2_deadtree51269"
 		Belong="-1"
 		Prototype="Breakable_r2_deadtree5"
-		Pos="2854.350 319.472 1044.656"
+		Pos="2854.350 319.533 1044.656"
 		Rot="0.000 0.199 0.000 0.980"
 		NodeScale="0.820" />
 
@@ -13636,7 +13443,7 @@
 		Name="r2_deadtree51271"
 		Belong="-1"
 		Prototype="Breakable_r2_deadtree5"
-		Pos="2863.209 323.758 992.001"
+		Pos="2863.209 323.548 992.001"
 		Rot="0.000 0.199 0.000 0.980"
 		NodeScale="0.830" />
 
@@ -13904,7 +13711,7 @@
 		Name="r2_deadtree21307"
 		Belong="-1"
 		Prototype="Breakable_r2_deadtree2"
-		Pos="938.885 271.504 3175.588"
+		Pos="938.885 271.638 3175.588"
 		NodeScale="1.010" />
 
 	<Object
@@ -14053,7 +13860,7 @@
 		Name="r2_deadtree31326"
 		Belong="-1"
 		Prototype="Breakable_r2_deadtree3"
-		Pos="1415.668 237.963 1832.010"
+		Pos="1415.668 236.042 1832.010"
 		Rot="0.000 -0.996 0.000 0.087"
 		NodeScale="1.020" />
 
@@ -14277,7 +14084,7 @@
 		Name="r2_deadtree41354"
 		Belong="-1"
 		Prototype="Breakable_r2_deadtree4"
-		Pos="1343.664 261.848 1452.176"
+		Pos="1343.664 237.434 1452.176"
 		Rot="0.000 -0.895 0.000 0.446"
 		NodeScale="0.830" />
 
@@ -14507,14 +14314,14 @@
 		Name="r2_deadtree41383"
 		Belong="-1"
 		Prototype="Breakable_r2_deadtree4"
-		Pos="2426.211 306.898 2120.385"
+		Pos="2426.211 306.045 2120.385"
 		Rot="0.000 -0.559 0.000 0.829" />
 
 	<Object
 		Name="r2_deadtree41384"
 		Belong="-1"
 		Prototype="Breakable_r2_deadtree4"
-		Pos="2455.998 301.126 2083.003"
+		Pos="2455.998 286.529 2083.003"
 		Rot="0.000 -0.707 0.000 0.707"
 		NodeScale="1.160" />
 
@@ -15571,7 +15378,7 @@
 		Name="dub3_r21518"
 		Belong="-1"
 		Prototype="Breakable_dub3_r2"
-		Pos="1526.358 292.217 2637.747"
+		Pos="1524.520 292.160 2639.193"
 		Rot="0.000 -0.588 0.000 0.809"
 		NodeScale="1.100" />
 
@@ -15579,7 +15386,7 @@
 		Name="dub3_r21519"
 		Belong="-1"
 		Prototype="Breakable_dub3_r2"
-		Pos="1510.267 292.397 2283.586"
+		Pos="1508.100 292.820 2273.071"
 		Rot="0.000 0.009 0.000 1.000"
 		NodeScale="0.920" />
 
@@ -15756,7 +15563,7 @@
 		Name="dub3_r21542"
 		Belong="-1"
 		Prototype="Breakable_dub3_r2"
-		Pos="1321.026 242.171 1453.042"
+		Pos="1321.026 240.744 1453.042"
 		Rot="0.000 -0.646 0.000 0.763"
 		NodeScale="1.094" />
 
@@ -16021,7 +15828,7 @@
 		Name="Breakable_Stolb11588"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1792.096 316.476 3302.560"
+		Pos="1792.096 316.446 3302.560"
 		Rot="0.000 -0.535 0.000 0.845" />
 
 	<Object
@@ -16274,86 +16081,86 @@
 		Name="Breakable_Stolb11629"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1368.521 236.226 1647.772" />
+		Pos="1368.521 236.172 1647.772" />
 
 	<Object
 		Name="Breakable_Stolb11630"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1378.940 236.140 1711.282" />
+		Pos="1378.940 236.086 1711.282" />
 
 	<Object
 		Name="Breakable_Stolb11631"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1407.079 236.161 1764.192" />
+		Pos="1407.079 236.107 1764.192" />
 
 	<Object
 		Name="Breakable_Stolb11632"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1448.585 236.274 1803.895" />
+		Pos="1448.585 236.221 1803.895" />
 
 	<Object
 		Name="Breakable_Stolb11633"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1477.141 236.337 1866.446" />
+		Pos="1477.141 236.283 1866.446" />
 
 	<Object
 		Name="Breakable_Stolb11634"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1521.408 236.309 1928.270"
+		Pos="1521.408 236.255 1928.270"
 		Rot="0.000 0.297 0.000 0.955" />
 
 	<Object
 		Name="Breakable_Stolb11635"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1594.720 236.099 1967.012"
+		Pos="1594.720 236.046 1967.012"
 		Rot="0.000 0.554 0.000 0.833" />
 
 	<Object
 		Name="Breakable_Stolb11636"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1637.505 236.114 1975.144"
+		Pos="1637.505 236.061 1975.144"
 		Rot="0.000 0.785 0.000 0.619" />
 
 	<Object
 		Name="Breakable_Stolb11637"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1707.271 235.989 1970.389"
+		Pos="1707.271 235.935 1970.389"
 		Rot="0.000 0.546 0.000 0.838" />
 
 	<Object
 		Name="Breakable_Stolb11638"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1760.258 236.288 1987.497"
+		Pos="1760.258 236.235 1987.497"
 		Rot="0.000 0.399 0.000 0.917" />
 
 	<Object
 		Name="Breakable_Stolb11639"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1813.199 236.115 2006.704"
+		Pos="1813.199 236.062 2006.704"
 		Rot="0.000 0.513 0.000 0.858" />
 
 	<Object
 		Name="Breakable_Stolb11640"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1862.425 236.342 2004.425"
+		Pos="1862.425 236.288 2004.425"
 		Rot="-0.017 0.582 0.023 0.813" />
 
 	<Object
 		Name="Breakable_Stolb11641"
 		Belong="1001"
 		Prototype="Breakable_Stolb1"
-		Pos="1906.573 236.635 1991.763" />
+		Pos="1906.573 236.625 1991.763" />
 
 	<Object
 		Name="Breakable_Stolb11642"
@@ -17529,7 +17336,7 @@
 		<Post
 			ServerObjName="Breakable_Stolb11588"
 			NodesNameHierarchy=""
-			PostTiePos="1792.194 322.885 3303.313"
+			PostTiePos="1792.194 322.854 3303.313"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -17545,7 +17352,7 @@
 		<Post
 			ServerObjName="Breakable_Stolb11588"
 			NodesNameHierarchy=""
-			PostTiePos="1791.654 322.542 3302.172"
+			PostTiePos="1791.654 322.511 3302.172"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -17843,13 +17650,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11638"
 			NodesNameHierarchy=""
-			PostTiePos="1760.921 242.697 1987.127"
+			PostTiePos="1760.921 242.643 1987.127"
 			LpName="LP_PART01" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11639"
 			NodesNameHierarchy=""
-			PostTiePos="1813.746 242.524 2006.178"
+			PostTiePos="1813.746 242.470 2006.178"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -17859,13 +17666,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11638"
 			NodesNameHierarchy=""
-			PostTiePos="1760.061 242.354 1988.051"
+			PostTiePos="1760.061 242.300 1988.051"
 			LpName="LP_PART02" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11639"
 			NodesNameHierarchy=""
-			PostTiePos="1813.149 242.180 2007.290"
+			PostTiePos="1813.149 242.127 2007.290"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -17875,13 +17682,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11639"
 			NodesNameHierarchy=""
-			PostTiePos="1813.746 242.524 2006.178"
+			PostTiePos="1813.746 242.470 2006.178"
 			LpName="LP_PART01" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11640"
 			NodesNameHierarchy=""
-			PostTiePos="1862.512 242.766 2003.811"
+			PostTiePos="1862.512 242.712 2003.811"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -17891,13 +17698,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11639"
 			NodesNameHierarchy=""
-			PostTiePos="1813.149 242.180 2007.290"
+			PostTiePos="1813.149 242.127 2007.290"
 			LpName="LP_PART02" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11640"
 			NodesNameHierarchy=""
-			PostTiePos="1862.125 242.401 2005.006"
+			PostTiePos="1862.125 242.347 2005.006"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -17907,13 +17714,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11640"
 			NodesNameHierarchy=""
-			PostTiePos="1862.512 242.766 2003.811"
+			PostTiePos="1862.512 242.712 2003.811"
 			LpName="LP_PART01" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11641"
 			NodesNameHierarchy=""
-			PostTiePos="1907.296 243.044 1991.996"
+			PostTiePos="1907.296 243.033 1991.996"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -17923,13 +17730,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11640"
 			NodesNameHierarchy=""
-			PostTiePos="1862.125 242.401 2005.006"
+			PostTiePos="1862.125 242.347 2005.006"
 			LpName="LP_PART02" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11641"
 			NodesNameHierarchy=""
-			PostTiePos="1906.033 242.701 1991.996"
+			PostTiePos="1906.033 242.690 1991.996"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -17939,13 +17746,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11637"
 			NodesNameHierarchy=""
-			PostTiePos="1707.776 242.397 1969.822"
+			PostTiePos="1707.776 242.344 1969.822"
 			LpName="LP_PART01" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11638"
 			NodesNameHierarchy=""
-			PostTiePos="1760.921 242.697 1987.127"
+			PostTiePos="1760.921 242.643 1987.127"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -17955,13 +17762,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11637"
 			NodesNameHierarchy=""
-			PostTiePos="1707.266 242.054 1970.977"
+			PostTiePos="1707.266 242.000 1970.977"
 			LpName="LP_PART02" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11638"
 			NodesNameHierarchy=""
-			PostTiePos="1760.061 242.354 1988.051"
+			PostTiePos="1760.061 242.300 1988.051"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -17971,13 +17778,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11634"
 			NodesNameHierarchy=""
-			PostTiePos="1522.135 242.717 1928.052"
+			PostTiePos="1522.135 242.664 1928.052"
 			LpName="LP_PART01" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11635"
 			NodesNameHierarchy=""
-			PostTiePos="1595.214 242.508 1966.436"
+			PostTiePos="1595.214 242.454 1966.436"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -17987,13 +17794,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11634"
 			NodesNameHierarchy=""
-			PostTiePos="1521.096 242.374 1928.768"
+			PostTiePos="1521.096 242.320 1928.768"
 			LpName="LP_PART02" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11635"
 			NodesNameHierarchy=""
-			PostTiePos="1594.726 242.165 1967.600"
+			PostTiePos="1594.726 242.111 1967.600"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -18003,13 +17810,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11635"
 			NodesNameHierarchy=""
-			PostTiePos="1595.214 242.508 1966.436"
+			PostTiePos="1595.214 242.454 1966.436"
 			LpName="LP_PART01" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11636"
 			NodesNameHierarchy=""
-			PostTiePos="1637.563 242.523 1974.387"
+			PostTiePos="1637.563 242.469 1974.387"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -18019,13 +17826,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11635"
 			NodesNameHierarchy=""
-			PostTiePos="1594.726 242.165 1967.600"
+			PostTiePos="1594.726 242.111 1967.600"
 			LpName="LP_PART02" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11636"
 			NodesNameHierarchy=""
-			PostTiePos="1637.858 242.179 1975.615"
+			PostTiePos="1637.858 242.126 1975.615"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -18035,13 +17842,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11636"
 			NodesNameHierarchy=""
-			PostTiePos="1637.563 242.523 1974.387"
+			PostTiePos="1637.563 242.469 1974.387"
 			LpName="LP_PART01" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11637"
 			NodesNameHierarchy=""
-			PostTiePos="1707.776 242.397 1969.822"
+			PostTiePos="1707.776 242.344 1969.822"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -18051,13 +17858,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11636"
 			NodesNameHierarchy=""
-			PostTiePos="1637.858 242.179 1975.615"
+			PostTiePos="1637.858 242.126 1975.615"
 			LpName="LP_PART02" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11637"
 			NodesNameHierarchy=""
-			PostTiePos="1707.266 242.054 1970.977"
+			PostTiePos="1707.266 242.000 1970.977"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -18067,13 +17874,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11630"
 			NodesNameHierarchy=""
-			PostTiePos="1379.663 242.548 1711.515"
+			PostTiePos="1379.663 242.495 1711.515"
 			LpName="LP_PART01" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11631"
 			NodesNameHierarchy=""
-			PostTiePos="1407.802 242.569 1764.425"
+			PostTiePos="1407.802 242.516 1764.425"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -18083,30 +17890,14 @@
 		<Post
 			ServerObjName="Breakable_Stolb11630"
 			NodesNameHierarchy=""
-			PostTiePos="1378.400 242.205 1711.515"
+			PostTiePos="1378.400 242.151 1711.515"
 			LpName="LP_PART02" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11631"
 			NodesNameHierarchy=""
-			PostTiePos="1406.539 242.226 1764.425"
+			PostTiePos="1406.539 242.172 1764.425"
 			LpName="LP_PART02" />
-	</Object>
-
-	<Object
-		Belong="-1"
-		Prototype="Cable_1">
-		<Post
-			ServerObjName="Breakable_Stolb11631"
-			NodesNameHierarchy=""
-			PostTiePos="1407.802 242.569 1764.425"
-			LpName="LP_PART01" />
-
-		<Post
-			ServerObjName="Breakable_Stolb11632"
-			NodesNameHierarchy=""
-			PostTiePos="1449.308 242.683 1804.128"
-			LpName="LP_PART01" />
 	</Object>
 
 	<Object
@@ -18115,29 +17906,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11631"
 			NodesNameHierarchy=""
-			PostTiePos="1406.539 242.226 1764.425"
-			LpName="LP_PART02" />
-
-		<Post
-			ServerObjName="Breakable_Stolb11632"
-			NodesNameHierarchy=""
-			PostTiePos="1448.045 242.340 1804.128"
-			LpName="LP_PART02" />
-	</Object>
-
-	<Object
-		Belong="-1"
-		Prototype="Cable_1">
-		<Post
-			ServerObjName="Breakable_Stolb11632"
-			NodesNameHierarchy=""
-			PostTiePos="1449.308 242.683 1804.128"
+			PostTiePos="1407.802 242.516 1764.425"
 			LpName="LP_PART01" />
 
 		<Post
-			ServerObjName="Breakable_Stolb11633"
+			ServerObjName="Breakable_Stolb11632"
 			NodesNameHierarchy=""
-			PostTiePos="1477.864 242.745 1866.679"
+			PostTiePos="1449.308 242.629 1804.128"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -18145,15 +17920,47 @@
 		Belong="-1"
 		Prototype="Cable_1">
 		<Post
+			ServerObjName="Breakable_Stolb11631"
+			NodesNameHierarchy=""
+			PostTiePos="1406.539 242.172 1764.425"
+			LpName="LP_PART02" />
+
+		<Post
 			ServerObjName="Breakable_Stolb11632"
 			NodesNameHierarchy=""
-			PostTiePos="1448.045 242.340 1804.128"
+			PostTiePos="1448.045 242.286 1804.128"
+			LpName="LP_PART02" />
+	</Object>
+
+	<Object
+		Belong="-1"
+		Prototype="Cable_1">
+		<Post
+			ServerObjName="Breakable_Stolb11632"
+			NodesNameHierarchy=""
+			PostTiePos="1449.308 242.629 1804.128"
+			LpName="LP_PART01" />
+
+		<Post
+			ServerObjName="Breakable_Stolb11633"
+			NodesNameHierarchy=""
+			PostTiePos="1477.864 242.692 1866.679"
+			LpName="LP_PART01" />
+	</Object>
+
+	<Object
+		Belong="-1"
+		Prototype="Cable_1">
+		<Post
+			ServerObjName="Breakable_Stolb11632"
+			NodesNameHierarchy=""
+			PostTiePos="1448.045 242.286 1804.128"
 			LpName="LP_PART02" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11633"
 			NodesNameHierarchy=""
-			PostTiePos="1476.601 242.402 1866.679"
+			PostTiePos="1476.601 242.349 1866.679"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -18163,13 +17970,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11633"
 			NodesNameHierarchy=""
-			PostTiePos="1477.864 242.745 1866.679"
+			PostTiePos="1477.864 242.692 1866.679"
 			LpName="LP_PART01" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11634"
 			NodesNameHierarchy=""
-			PostTiePos="1522.135 242.717 1928.052"
+			PostTiePos="1522.135 242.664 1928.052"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -18179,13 +17986,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11633"
 			NodesNameHierarchy=""
-			PostTiePos="1476.601 242.402 1866.679"
+			PostTiePos="1476.601 242.349 1866.679"
 			LpName="LP_PART02" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11634"
 			NodesNameHierarchy=""
-			PostTiePos="1521.096 242.374 1928.768"
+			PostTiePos="1521.096 242.320 1928.768"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -18265,7 +18072,7 @@
 		<Post
 			ServerObjName="Breakable_Stolb11629"
 			NodesNameHierarchy=""
-			PostTiePos="1369.244 242.634 1648.005"
+			PostTiePos="1369.244 242.581 1648.005"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -18281,7 +18088,7 @@
 		<Post
 			ServerObjName="Breakable_Stolb11629"
 			NodesNameHierarchy=""
-			PostTiePos="1367.981 242.291 1648.005"
+			PostTiePos="1367.981 242.238 1648.005"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -18291,13 +18098,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11629"
 			NodesNameHierarchy=""
-			PostTiePos="1369.244 242.634 1648.005"
+			PostTiePos="1369.244 242.581 1648.005"
 			LpName="LP_PART01" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11630"
 			NodesNameHierarchy=""
-			PostTiePos="1379.663 242.548 1711.515"
+			PostTiePos="1379.663 242.495 1711.515"
 			LpName="LP_PART01" />
 	</Object>
 
@@ -18307,13 +18114,13 @@
 		<Post
 			ServerObjName="Breakable_Stolb11629"
 			NodesNameHierarchy=""
-			PostTiePos="1367.981 242.291 1648.005"
+			PostTiePos="1367.981 242.238 1648.005"
 			LpName="LP_PART02" />
 
 		<Post
 			ServerObjName="Breakable_Stolb11630"
 			NodesNameHierarchy=""
-			PostTiePos="1378.400 242.205 1711.515"
+			PostTiePos="1378.400 242.151 1711.515"
 			LpName="LP_PART02" />
 	</Object>
 
@@ -19669,11 +19476,11 @@
 		Name="lamppost31677"
 		Belong="1001"
 		Prototype="lamppost3"
-		Pos="3052.009 312.453 1096.195">
+		Pos="3049.489 312.765 1096.315">
 		<Object
 			Belong="1001"
 			Prototype="LightObject2"
-			Pos="3052.109 325.014 1096.221"
+			Pos="3049.589 325.014 1096.341"
 			Rot="0.998 0.000 0.000 0.060" />
 	</Object>
 
@@ -19692,4 +19499,25 @@
 	<Object
 		Belong="1100"
 		Prototype="someRecollection" />
+
+	<Object
+		Name="Breakable_WoodFence21679"
+		Belong="1001"
+		Prototype="Breakable_WoodFence2"
+		Pos="1349.563 236.000 1653.369"
+		Rot="0.000 0.716 0.000 0.698" />
+
+	<Object
+		Name="Breakable_WoodFence21680"
+		Belong="1001"
+		Prototype="Breakable_WoodFence2"
+		Pos="1349.673 236.000 1664.920"
+		Rot="0.000 0.707 0.000 0.707" />
+
+	<Object
+		Name="Breakable_WoodFence21681"
+		Belong="1001"
+		Prototype="Breakable_WoodFence2"
+		Pos="1349.428 236.000 1676.063"
+		Rot="0.000 0.687 0.000 0.727" />
 </DynamicScene>

--- a/patch/maps/r2m2/dynamicscene.xml
+++ b/patch/maps/r2m2/dynamicscene.xml
@@ -4399,296 +4399,259 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1351.115 236.000 1670.368"
-		Rot="0.000 0.698 0.000 0.716"
-		NodeScale="1.119" />
+		Rot="0.000 0.698 0.000 0.716" />
 
 	<Object
 		Name="wood_fence288"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1351.476 236.000 1654.265"
-		Rot="0.000 0.698 0.000 0.716"
-		NodeScale="1.119" />
+		Rot="0.000 0.698 0.000 0.716" />
 
 	<Object
 		Name="wood_fence289"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1351.075 236.000 1639.341"
-		Rot="0.000 0.698 0.000 0.716"
-		NodeScale="1.119" />
+		Rot="0.000 0.698 0.000 0.716" />
 
 	<Object
 		Name="wood_fence290"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1351.098 236.000 1622.252"
-		Rot="0.000 0.698 0.000 0.716"
-		NodeScale="1.119" />
+		Rot="0.000 0.698 0.000 0.716" />
 
 	<Object
 		Name="wood_fence291"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1349.946 236.000 1604.994"
-		Rot="0.000 0.698 0.000 0.716"
-		NodeScale="1.119" />
+		Rot="0.000 0.698 0.000 0.716" />
 
 	<Object
 		Name="wood_fence292"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1348.841 236.000 1586.342"
-		Rot="0.000 0.698 0.000 0.716"
-		NodeScale="1.119" />
+		Rot="0.000 0.698 0.000 0.716" />
 
 	<Object
 		Name="wood_fence293"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1347.771 236.174 1567.586"
-		Rot="0.000 0.698 0.000 0.716"
-		NodeScale="1.119" />
+		Rot="0.000 0.698 0.000 0.716" />
 
 	<Object
 		Name="wood_fence294"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1352.767 236.011 1682.398"
-		Rot="0.000 0.820 0.000 0.572"
-		NodeScale="1.119" />
+		Rot="0.000 0.820 0.000 0.572" />
 
 	<Object
 		Name="wood_fence295"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1455.652 251.018 1676.158"
-		Rot="0.000 -1.000 0.000 0.000"
-		NodeScale="1.119" />
+		Rot="0.000 -1.000 0.000 0.000" />
 
 	<Object
 		Name="wood_fence296"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1438.808 251.055 1675.584"
-		Rot="0.000 -1.000 0.000 0.000"
-		NodeScale="1.119" />
+		Rot="0.000 -1.000 0.000 0.000" />
 
 	<Object
 		Name="wood_fence297"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1431.993 251.143 1668.481"
-		Rot="0.000 -0.687 0.000 0.727"
-		NodeScale="1.119" />
+		Rot="0.000 -0.687 0.000 0.727" />
 
 	<Object
 		Name="wood_fence298"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1431.158 250.979 1656.580"
-		Rot="0.000 -0.687 0.000 0.727"
-		NodeScale="1.119" />
+		Rot="0.000 -0.687 0.000 0.727" />
 
 	<Object
 		Name="wood_fence299"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1430.421 250.915 1644.511"
-		Rot="0.000 -0.687 0.000 0.727"
-		NodeScale="1.119" />
+		Rot="0.000 -0.687 0.000 0.727" />
 
 	<Object
 		Name="wood_fence2100"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1430.137 251.002 1631.894"
-		Rot="0.000 -0.687 0.000 0.727"
-		NodeScale="1.119" />
+		Rot="0.000 -0.687 0.000 0.727" />
 
 	<Object
 		Name="wood_fence2101"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1429.618 251.093 1619.734"
-		Rot="0.000 -0.687 0.000 0.727"
-		NodeScale="1.119" />
+		Rot="0.000 -0.687 0.000 0.727" />
 
 	<Object
 		Name="wood_fence2102"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="1429.022 251.177 1597.113"
-		Rot="0.000 -0.724 0.000 0.690"
-		NodeScale="1.119" />
+		Rot="0.000 -0.724 0.000 0.690" />
 
 	<Object
 		Name="wood_fence2103"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2297.252 273.551 2191.290"
-		Rot="0.000 -1.000 0.000 0.000"
-		NodeScale="1.119" />
+		Rot="0.000 -1.000 0.000 0.000" />
 
 	<Object
 		Name="wood_fence2104"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2282.884 273.747 2193.281"
-		Rot="0.000 -1.000 0.000 0.000"
-		NodeScale="1.119" />
+		Rot="0.000 -1.000 0.000 0.000" />
 
 	<Object
 		Name="wood_fence2105"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2269.263 273.315 2193.033"
-		Rot="0.000 -1.000 0.000 0.000"
-		NodeScale="1.119" />
+		Rot="0.000 -1.000 0.000 0.000" />
 
 	<Object
 		Name="wood_fence2108"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2241.079 273.272 2163.976"
-		Rot="0.000 0.929 0.000 0.371"
-		NodeScale="1.119" />
+		Rot="0.000 0.929 0.000 0.371" />
 
 	<Object
 		Name="wood_fence2109"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2229.984 273.114 2159.406"
-		Rot="0.000 0.995 0.000 0.102"
-		NodeScale="1.119" />
+		Rot="0.000 0.995 0.000 0.102" />
 
 	<Object
 		Name="wood_fence2110"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2217.888 273.404 2153.256"
-		Rot="0.000 0.926 0.000 0.377"
-		NodeScale="1.119" />
+		Rot="0.000 0.926 0.000 0.377" />
 
 	<Object
 		Name="wood_fence2111"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2210.407 273.421 2142.503"
-		Rot="0.000 0.805 0.000 0.593"
-		NodeScale="1.119" />
+		Rot="0.000 0.805 0.000 0.593" />
 
 	<Object
 		Name="wood_fence2112"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2071.233 253.200 2123.887"
-		Rot="0.000 0.896 0.000 0.445"
-		NodeScale="1.119" />
+		Rot="0.000 0.896 0.000 0.445" />
 
 	<Object
 		Name="wood_fence2113"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2079.128 255.676 2134.082"
-		Rot="0.000 0.890 0.000 0.456"
-		NodeScale="1.119" />
+		Rot="0.000 0.890 0.000 0.456" />
 
 	<Object
 		Name="wood_fence2114"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2085.462 257.426 2143.625"
-		Rot="0.000 0.863 0.000 0.505"
-		NodeScale="1.119" />
+		Rot="0.000 0.863 0.000 0.505" />
 
 	<Object
 		Name="wood_fence2115"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2080.999 258.217 2150.013"
-		Rot="0.000 0.124 0.000 0.992"
-		NodeScale="1.119" />
+		Rot="0.000 0.124 0.000 0.992" />
 
 	<Object
 		Name="wood_fence2116"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2176.311 259.200 2248.920"
-		Rot="0.000 0.948 0.000 0.319"
-		NodeScale="1.119" />
+		Rot="0.000 0.948 0.000 0.319" />
 
 	<Object
 		Name="wood_fence2117"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2122.857 259.914 2179.438"
-		Rot="0.000 0.876 0.000 0.483"
-		NodeScale="1.119" />
+		Rot="0.000 0.876 0.000 0.483" />
 
 	<Object
 		Name="wood_fence2118"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2129.947 259.955 2190.200"
-		Rot="0.000 0.876 0.000 0.483"
-		NodeScale="1.119" />
+		Rot="0.000 0.876 0.000 0.483" />
 
 	<Object
 		Name="wood_fence2119"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2112.901 260.439 2178.080"
-		Rot="0.000 -0.977 0.000 0.214"
-		NodeScale="1.119" />
+		Rot="0.000 -0.977 0.000 0.214" />
 
 	<Object
 		Name="wood_fence2120"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2126.899 260.585 2197.875"
-		Rot="0.000 0.231 0.000 0.973"
-		NodeScale="1.119" />
+		Rot="0.000 0.231 0.000 0.973" />
 
 	<Object
 		Name="wood_fence2121"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2165.070 259.960 2249.353"
-		Rot="0.000 -0.977 0.000 0.214"
-		NodeScale="1.119" />
+		Rot="0.000 -0.977 0.000 0.214" />
 
 	<Object
 		Name="wood_fence2122"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2185.694 258.617 2257.446"
-		Rot="0.000 0.881 0.000 0.473"
-		NodeScale="1.119" />
+		Rot="0.000 0.881 0.000 0.473" />
 
 	<Object
 		Name="wood_fence2123"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2115.497 261.662 2086.927"
-		Rot="0.000 0.018 0.000 1.000"
-		NodeScale="1.119" />
+		Rot="0.000 0.018 0.000 1.000" />
 
 	<Object
 		Name="wood_fence2124"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2109.266 261.257 2080.396"
-		Rot="0.000 -0.685 0.000 0.728"
-		NodeScale="1.119" />
+		Rot="0.000 -0.685 0.000 0.728" />
 
 	<Object
 		Name="wood_fence2125"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2108.792 261.225 2067.972"
-		Rot="0.000 -0.685 0.000 0.728"
-		NodeScale="1.119" />
+		Rot="0.000 -0.685 0.000 0.728" />
 
 	<Object
 		Name="factory_box126"
@@ -5699,7 +5662,7 @@
 		Prototype="Breakable_WoodFence2"
 		Pos="1429.034 251.171 1608.260"
 		Rot="0.000 -0.687 0.000 0.727"
-		NodeScale="1.119" />
+		 />
 
 	<Object
 		Name="wood_fence2254"
@@ -5707,7 +5670,7 @@
 		Prototype="Breakable_WoodFence2"
 		Pos="1429.483 251.184 1586.008"
 		Rot="0.000 -0.724 0.000 0.690"
-		NodeScale="1.119" />
+		 />
 
 	<Object
 		Name="wood_fence2255"
@@ -5715,7 +5678,7 @@
 		Prototype="Breakable_WoodFence2"
 		Pos="1430.641 251.200 1575.140"
 		Rot="0.000 -0.749 0.000 0.663"
-		NodeScale="1.119" />
+		 />
 
 	<Object
 		Name="wood_fence2256"
@@ -5723,7 +5686,7 @@
 		Prototype="Breakable_WoodFence2"
 		Pos="1432.073 251.222 1564.097"
 		Rot="0.000 -0.749 0.000 0.663"
-		NodeScale="1.119" />
+		 />
 
 	<Object
 		Name="wood_fence2257"
@@ -6047,136 +6010,119 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2314.590 251.786 1345.634"
-		Rot="0.000 0.875 0.000 0.485"
-		NodeScale="1.119" />
+		Rot="0.000 0.875 0.000 0.485" />
 
 	<Object
 		Name="wood_fence2303"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2305.885 252.065 1339.858"
-		Rot="0.000 0.995 0.000 0.104"
-		NodeScale="1.119" />
+		Rot="0.000 0.995 0.000 0.104" />
 
 	<Object
 		Name="wood_fence2304"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2284.743 257.031 1377.241"
-		Rot="0.000 0.646 0.000 0.763"
-		NodeScale="1.119" />
+		Rot="0.000 0.646 0.000 0.763" />
 
 	<Object
 		Name="wood_fence2305"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2316.613 251.790 1355.940"
-		Rot="0.000 0.646 0.000 0.763"
-		NodeScale="1.119" />
+		Rot="0.000 0.646 0.000 0.763" />
 
 	<Object
 		Name="wood_fence2306"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2316.207 251.872 1367.060"
-		Rot="-0.019 0.680 0.002 0.733"
-		NodeScale="1.119" />
+		Rot="-0.019 0.680 0.002 0.733" />
 
 	<Object
 		Name="wood_fence2307"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2315.862 252.312 1378.535"
-		Rot="-0.012 0.677 -0.013 0.736"
-		NodeScale="1.119" />
+		Rot="-0.012 0.677 -0.013 0.736" />
 
 	<Object
 		Name="wood_fence2308"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2315.094 252.946 1389.904"
-		Rot="-0.010 0.677 -0.011 0.736"
-		NodeScale="1.119" />
+		Rot="-0.010 0.677 -0.011 0.736" />
 
 	<Object
 		Name="wood_fence2309"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2309.114 253.918 1395.738"
-		Rot="0.000 -0.002 0.000 1.000"
-		NodeScale="1.119" />
+		Rot="0.000 -0.002 0.000 1.000" />
 
 	<Object
 		Name="wood_fence2310"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2302.799 256.380 1414.082"
-		Rot="0.000 0.997 0.000 0.078"
-		NodeScale="1.119" />
+		Rot="0.000 0.997 0.000 0.078" />
 
 	<Object
 		Name="wood_fence2311"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2306.405 256.536 1454.277"
-		Rot="0.000 0.677 0.000 0.736"
-		NodeScale="1.119" />
+		Rot="0.000 0.677 0.000 0.736" />
 
 	<Object
 		Name="wood_fence2312"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2307.172 256.394 1442.909"
-		Rot="0.000 0.677 0.000 0.736"
-		NodeScale="1.119" />
+		Rot="0.000 0.677 0.000 0.736" />
 
 	<Object
 		Name="wood_fence2313"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2307.517 255.814 1431.433"
-		Rot="0.000 0.677 0.000 0.736"
-		NodeScale="1.119" />
+		Rot="0.000 0.677 0.000 0.736" />
 
 	<Object
 		Name="wood_fence2314"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2307.923 255.753 1420.314"
-		Rot="0.000 0.646 0.000 0.763"
-		NodeScale="1.119" />
+		Rot="0.000 0.646 0.000 0.763" />
 
 	<Object
 		Name="wood_fence2315"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2343.007 251.995 1394.599"
-		Rot="-0.006 -0.740 0.006 0.672"
-		NodeScale="1.119" />
+		Rot="-0.006 -0.740 0.006 0.672" />
 
 	<Object
 		Name="wood_fence2316"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2342.397 251.752 1383.488"
-		Rot="-0.006 -0.704 0.006 0.710"
-		NodeScale="1.119" />
+		Rot="-0.006 -0.704 0.006 0.710" />
 
 	<Object
 		Name="wood_fence2317"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2341.690 251.693 1372.030"
-		Rot="0.000 -0.704 0.000 0.710"
-		NodeScale="1.119" />
+		Rot="0.000 -0.704 0.000 0.710" />
 
 	<Object
 		Name="wood_fence2318"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2341.412 251.602 1360.639"
-		Rot="0.000 -0.704 0.000 0.710"
-		NodeScale="1.119" />
+		Rot="0.000 -0.704 0.000 0.710" />
 
 	<Object
 		Name="wood_fence2319"
@@ -6199,24 +6145,21 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2390.367 259.112 1416.380"
-		Rot="-0.032 -0.647 0.029 0.761"
-		NodeScale="1.119" />
+		Rot="-0.032 -0.647 0.029 0.761" />
 
 	<Object
 		Name="wood_fence2322"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2384.222 258.272 1411.167"
-		Rot="0.001 0.033 0.017 0.999"
-		NodeScale="1.119" />
+		Rot="0.001 0.033 0.017 0.999" />
 
 	<Object
 		Name="wood_fence2323"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2373.936 256.779 1411.899"
-		Rot="0.003 0.033 0.078 0.996"
-		NodeScale="1.119" />
+		Rot="0.003 0.033 0.078 0.996" />
 
 	<Object
 		Name="wood_fence2324"
@@ -6231,8 +6174,7 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2345.157 251.485 1351.639"
-		Rot="0.000 -0.922 0.000 0.387"
-		NodeScale="1.119" />
+		Rot="0.000 -0.922 0.000 0.387" />
 
 	<Object
 		Name="wood_fence2326"
@@ -6240,47 +6182,42 @@
 		Prototype="Breakable_WoodFence2"
 		Pos="2353.960 251.009 1349.094"
 		Rot="0.000 0.995 0.000 0.104"
-		NodeScale="1.119" />
+		 />
 
 	<Object
 		Name="wood_fence2327"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2394.389 256.635 1468.400"
-		Rot="0.000 -0.820 0.000 0.572"
-		NodeScale="1.119" />
+		Rot="0.000 -0.820 0.000 0.572" />
 
 	<Object
 		Name="wood_fence2328"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2394.069 256.712 1447.306"
-		Rot="0.000 -0.612 0.000 0.791"
-		NodeScale="1.119" />
+		Rot="0.000 -0.612 0.000 0.791" />
 
 	<Object
 		Name="wood_fence2329"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2395.430 256.827 1457.943"
-		Rot="0.000 -0.704 0.000 0.710"
-		NodeScale="1.119" />
+		Rot="0.000 -0.704 0.000 0.710" />
 
 	<Object
 		Name="wood_fence2330"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2286.064 266.627 1492.394"
-		Rot="0.000 -0.994 0.000 0.107"
-		NodeScale="1.119" />
+		Rot="0.000 -0.994 0.000 0.107" />
 
 	<Object
 		Name="wood_fence2331"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2293.473 266.519 1496.319"
-		Rot="0.000 0.840 0.000 0.543"
-		NodeScale="1.119" />
+		Rot="0.000 0.840 0.000 0.543" />
 
 	<Object
 		Name="wood_fence2332"
@@ -6288,111 +6225,98 @@
 		Prototype="Breakable_WoodFence2"
 		Pos="2299.975 266.709 1504.725"
 		Rot="0.000 0.936 0.000 0.352"
-		NodeScale="1.119" />
+		 />
 
 	<Object
 		Name="wood_fence2333"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2300.544 256.821 1460.865"
-		Rot="0.000 0.100 0.000 0.995"
-		NodeScale="1.119" />
+		Rot="0.000 0.100 0.000 0.995" />
 
 	<Object
 		Name="wood_fence2334"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2259.370 266.583 1482.877"
-		Rot="-0.021 0.750 -0.019 0.661"
-		NodeScale="1.119" />
+		Rot="-0.021 0.750 -0.019 0.661" />
 
 	<Object
 		Name="wood_fence2335"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2259.543 265.414 1471.726"
-		Rot="-0.014 0.649 -0.017 0.760"
-		NodeScale="1.119" />
+		Rot="-0.014 0.649 -0.017 0.760" />
 
 	<Object
 		Name="wood_fence2336"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2263.845 264.483 1462.425"
-		Rot="-0.009 0.383 -0.022 0.924"
-		NodeScale="1.119" />
+		Rot="-0.009 0.383 -0.022 0.924" />
 
 	<Object
 		Name="wood_fence2337"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2309.361 266.688 1509.771"
-		Rot="0.000 0.989 0.000 0.148"
-		NodeScale="1.119" />
+		Rot="0.000 0.989 0.000 0.148" />
 
 	<Object
 		Name="wood_fence2338"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2368.348 255.966 1500.297"
-		Rot="-0.043 -0.933 0.016 0.358"
-		NodeScale="1.119" />
+		Rot="-0.043 -0.933 0.016 0.358" />
 
 	<Object
 		Name="wood_fence2339"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2359.390 257.039 1505.249"
-		Rot="-0.038 -0.979 0.008 0.199"
-		NodeScale="1.119" />
+		Rot="-0.038 -0.979 0.008 0.199" />
 
 	<Object
 		Name="wood_fence2340"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2295.042 252.184 1337.664"
-		Rot="0.000 0.995 0.000 0.104"
-		NodeScale="1.119" />
+		Rot="0.000 0.995 0.000 0.104" />
 
 	<Object
 		Name="wood_fence2341"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2284.011 252.093 1335.906"
-		Rot="0.000 0.998 0.000 0.063"
-		NodeScale="1.119" />
+		Rot="0.000 0.998 0.000 0.063" />
 
 	<Object
 		Name="wood_fence2342"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2272.916 252.271 1334.405"
-		Rot="0.000 0.998 0.000 0.063"
-		NodeScale="1.119" />
+		Rot="0.000 0.998 0.000 0.063" />
 
 	<Object
 		Name="wood_fence2343"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2364.645 250.915 1351.711"
-		Rot="0.000 0.991 0.000 0.137"
-		NodeScale="1.119" />
+		Rot="0.000 0.991 0.000 0.137" />
 
 	<Object
 		Name="wood_fence2344"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2375.118 250.994 1354.620"
-		Rot="0.000 0.991 0.000 0.137"
-		NodeScale="1.119" />
+		Rot="0.000 0.991 0.000 0.137" />
 
 	<Object
 		Name="wood_fence2345"
 		Belong="-1"
 		Prototype="Breakable_WoodFence2"
 		Pos="2385.920 251.321 1357.684"
-		Rot="0.000 0.991 0.000 0.137"
-		NodeScale="1.119" />
+		Rot="0.000 0.991 0.000 0.137" />
 
 	<Object
 		Name="wood_fence2346"

--- a/patch/maps/r2m2/world.xml
+++ b/patch/maps/r2m2/world.xml
@@ -2,7 +2,7 @@
 <World
 	name="Object16"
 	class="SgNode"
-	LastId="76473578">
+	LastId="76473629">
 	<Node
 		name="Object12"
 		class="SgAnimatedModelNode"
@@ -545,7 +545,7 @@
 	<Node
 		name="Object257"
 		class="SgAnimatedModelNode"
-		org="1331.215 0.000 1674.713"
+		org="1334.622 0.000 1673.557"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -553,7 +553,7 @@
 	<Node
 		name="Object258"
 		class="SgAnimatedModelNode"
-		org="1331.724 0.000 1659.604"
+		org="1334.812 0.000 1656.944"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -561,7 +561,7 @@
 	<Node
 		name="Object259"
 		class="SgAnimatedModelNode"
-		org="1332.788 0.000 1647.206"
+		org="1334.857 0.000 1648.108"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -569,7 +569,7 @@
 	<Node
 		name="Object260"
 		class="SgAnimatedModelNode"
-		org="1332.894 0.000 1635.065"
+		org="1334.102 0.000 1635.693"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -577,7 +577,7 @@
 	<Node
 		name="Object261"
 		class="SgAnimatedModelNode"
-		org="1332.965 0.000 1622.130"
+		org="1333.752 0.000 1623.025"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -585,7 +585,7 @@
 	<Node
 		name="Object262"
 		class="SgAnimatedModelNode"
-		org="1333.398 0.000 1610.019"
+		org="1333.106 0.000 1610.705"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -770,7 +770,7 @@
 	<Node
 		name="Object311"
 		class="SgAnimatedModelNode"
-		org="1307.581 0.000 1674.575"
+		org="1309.512 0.000 1673.700"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -810,7 +810,7 @@
 	<Node
 		name="Object316"
 		class="SgAnimatedModelNode"
-		org="1311.336 0.000 1646.900"
+		org="1310.342 0.000 1649.113"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -866,7 +866,7 @@
 	<Node
 		name="Object328"
 		class="SgAnimatedModelNode"
-		org="1306.084 0.000 1655.053"
+		org="1310.019 0.000 1655.311"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -874,7 +874,7 @@
 	<Node
 		name="Object329"
 		class="SgAnimatedModelNode"
-		org="1282.376 0.000 1655.088"
+		org="1286.018 0.000 1654.890"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -882,7 +882,7 @@
 	<Node
 		name="Object330"
 		class="SgAnimatedModelNode"
-		org="1259.522 0.000 1655.145"
+		org="1261.536 0.000 1655.171"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -907,7 +907,7 @@
 	<Node
 		name="Object334"
 		class="SgAnimatedModelNode"
-		org="1331.573 0.000 1668.803"
+		org="1334.755 0.000 1662.903"
 		orgRel="1"
 		id="seedbed"
 		ndmAction="0" />
@@ -5498,7 +5498,7 @@
 		class="SgAnimatedModelNode"
 		org="3433.473 -4.598 1157.156"
 		orgRel="1"
-		rot="-0.0036 0.8423 0.0054 0.5391"
+		rot="-0.0091 0.8503 0.0017 0.5262"
 		scale="1.457 1.457 1.457"
 		id="arena_barricade8"
 		ndmAction="0" />
@@ -8173,99 +8173,81 @@
 	<Node
 		name="Object6144"
 		class="SgAnimatedModelNode"
-		org="3132.354 0.000 1005.775"
+		org="3131.323 0.000 1005.909"
 		orgRel="1"
-		rot="0.0015 -0.9969 0.0414 0.0675"
+		rot="0.0022 -0.9993 0.0173 0.0327"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object6145"
 		class="SgAnimatedModelNode"
-		org="3127.450 0.000 985.912"
+		org="3127.862 0.000 983.642"
 		orgRel="1"
-		rot="0.0052 -0.9868 0.0411 0.1563"
+		rot="-0.0024 -0.9917 0.0248 0.1259"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object6146"
 		class="SgAnimatedModelNode"
-		org="3128.270 0.000 1048.264"
+		org="3128.381 -0.006 1040.148"
 		orgRel="1"
-		rot="-0.0089 -0.9820 0.0405 -0.1842"
+		rot="-0.0221 -0.9926 0.0623 -0.1016"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object6147"
 		class="SgAnimatedModelNode"
-		org="3119.153 0.000 1066.694"
+		org="3120.289 0.000 1067.177"
 		orgRel="1"
-		rot="-0.0132 -0.9561 0.0393 -0.2901"
+		rot="-0.0082 -0.9636 0.0796 -0.2552"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object6148"
 		class="SgAnimatedModelNode"
-		org="3106.214 0.000 1082.305"
+		org="3107.743 0.000 1083.451"
 		orgRel="1"
-		rot="-0.0176 -0.9171 0.0375 -0.3964"
+		rot="-0.0286 -0.9266 0.0635 -0.3696"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object6149"
 		class="SgAnimatedModelNode"
-		org="3089.718 0.386 1094.188"
+		org="3090.447 0.386 1095.773"
 		orgRel="1"
-		rot="-0.0232 -0.8450 0.0344 -0.5332"
+		rot="-0.0377 -0.8306 0.0587 -0.5524"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object6150"
 		class="SgAnimatedModelNode"
-		org="3070.729 -0.459 1100.062"
+		org="3070.470 -0.459 1099.494"
 		orgRel="1"
-		rot="-0.0287 -0.7410 0.0299 -0.6702"
-		id="arena_barricade10"
-		ndmAction="0" />
-
-	<Node
-		name="Object6151"
-		class="SgAnimatedModelNode"
-		org="3050.237 -0.459 1100.281"
-		orgRel="1"
-		rot="-0.0321 -0.6555 0.0262 -0.7541"
-		id="arena_barricade10"
-		ndmAction="0" />
-
-	<Node
-		name="Object6152"
-		class="SgAnimatedModelNode"
-		org="3030.081 -0.459 1097.503"
-		orgRel="1"
-		rot="-0.0321 -0.6555 0.0262 -0.7541"
+		rot="-0.0351 -0.7122 0.0388 -0.7000"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object6153"
 		class="SgAnimatedModelNode"
-		org="3010.503 -0.459 1093.427"
+		org="3011.000 -0.459 1094.045"
 		orgRel="1"
-		rot="-0.0340 -0.5943 0.0236 -0.8032"
+		rot="-0.0338 -0.5961 0.0239 -0.8019"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object6154"
 		class="SgAnimatedModelNode"
-		org="2991.319 -0.459 1086.224"
+		org="2990.971 -0.459 1085.384"
 		orgRel="1"
-		rot="-0.0360 -0.5220 0.0206 -0.8519"
+		rot="-0.0243 -0.5054 0.0147 -0.8624"
 		id="arena_barricade10"
 		ndmAction="0" />
 
@@ -9534,16 +9516,16 @@
 	<Node
 		name="Object6493"
 		class="SgAnimatedModelNode"
-		org="1853.522 0.000 2139.933"
+		org="1851.796 0.000 2139.269"
 		orgRel="1"
-		rot="0.0995 0.4642 -0.0580 0.8782"
+		rot="0.1167 0.4630 -0.0671 0.8761"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object6494"
 		class="SgAnimatedModelNode"
-		org="1868.582 0.000 2153.017"
+		org="1868.122 0.000 2152.882"
 		orgRel="1"
 		rot="0.1051 0.3678 -0.0470 0.9227"
 		id="arena_barricade10"
@@ -9554,7 +9536,7 @@
 		class="SgAnimatedModelNode"
 		org="1886.242 0.300 2162.997"
 		orgRel="1"
-		rot="0.0322 0.5973 -0.0292 0.8008"
+		rot="0.0374 0.5971 -0.0331 0.8006"
 		id="arena_barricade10"
 		ndmAction="0" />
 
@@ -9570,25 +9552,25 @@
 	<Node
 		name="Object6497"
 		class="SgAnimatedModelNode"
-		org="1926.988 -0.171 2163.224"
+		org="1926.912 -0.171 2160.925"
 		orgRel="1"
-		rot="0.0221 0.8092 -0.0375 0.5859"
+		rot="0.0107 0.8488 -0.0191 0.5283"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object6498"
 		class="SgAnimatedModelNode"
-		org="1943.884 -0.171 2152.147"
+		org="1945.301 -0.171 2148.467"
 		orgRel="1"
-		rot="0.0129 0.9219 -0.0415 0.3849"
+		rot="0.0119 0.9124 -0.0418 0.4069"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object6499"
 		class="SgAnimatedModelNode"
-		org="1956.338 0.129 2135.877"
+		org="1958.578 0.129 2131.236"
 		orgRel="1"
 		rot="0.0071 0.9660 -0.0429 0.2549"
 		id="arena_barricade10"
@@ -9597,9 +9579,9 @@
 	<Node
 		name="Object6500"
 		class="SgAnimatedModelNode"
-		org="1968.821 -0.528 2120.248"
+		org="1969.514 -0.528 2111.527"
 		orgRel="1"
-		rot="0.0195 0.9223 -0.0780 0.3781"
+		rot="-0.0735 0.9482 -0.0874 0.2963"
 		id="arena_barricade10"
 		ndmAction="0" />
 
@@ -11040,9 +11022,9 @@
 	<Node
 		name="Object7351"
 		class="SgAnimatedModelNode"
-		org="2493.184 -0.690 1310.267"
+		org="2494.171 -0.690 1309.632"
 		orgRel="1"
-		rot="0.0000 -0.9954 0.0000 -0.0959"
+		rot="0.0000 -0.9996 0.0000 -0.0284"
 		id="arena_barricade10"
 		ndmAction="0" />
 
@@ -11060,7 +11042,7 @@
 		class="SgAnimatedModelNode"
 		org="2449.464 -0.813 1353.352"
 		orgRel="1"
-		rot="0.0000 -0.7674 0.0000 -0.6411"
+		rot="0.0000 -0.7632 0.0000 -0.6461"
 		id="arena_barricade10"
 		ndmAction="0" />
 
@@ -11085,36 +11067,36 @@
 	<Node
 		name="Object7357"
 		class="SgAnimatedModelNode"
-		org="2527.760 -0.623 1306.752"
+		org="2527.357 -0.623 1308.761"
 		orgRel="1"
-		rot="0.0000 -0.3297 0.0000 -0.9441"
+		rot="0.0000 -0.3111 0.0000 -0.9504"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object7358"
 		class="SgAnimatedModelNode"
-		org="2560.318 -0.623 1315.716"
+		org="2558.761 -0.620 1312.025"
 		orgRel="1"
-		rot="0.0000 0.9312 0.0000 -0.3645"
+		rot="-0.0007 0.9803 -0.0021 -0.1973"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object7359"
 		class="SgAnimatedModelNode"
-		org="2576.427 -0.623 1326.906"
+		org="2575.931 -0.623 1327.047"
 		orgRel="1"
-		rot="0.0000 0.8052 0.0000 -0.5931"
+		rot="-0.0278 0.7407 0.0071 -0.6712"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object7360"
 		class="SgAnimatedModelNode"
-		org="2476.217 -0.530 1351.248"
+		org="2475.765 -0.530 1351.572"
 		orgRel="1"
-		rot="0.0000 -0.7284 0.0000 -0.6852"
+		rot="0.0075 -0.6978 0.0180 -0.7161"
 		id="arena_barricade10"
 		ndmAction="0" />
 
@@ -11247,37 +11229,27 @@
 		ndmAction="0" />
 
 	<Node
-		name="Object7464"
-		class="SgAnimatedModelNode"
-		org="3050.264 0.000 1035.503"
-		orgRel="1"
-		rot="0.0000 0.9987 0.0000 0.0501"
-		scale="0.890 0.890 0.890"
-		id="arena_barricade10"
-		ndmAction="0" />
-
-	<Node
 		name="Object7466"
 		class="SgAnimatedModelNode"
-		org="3040.896 0.000 1002.669"
+		org="3044.940 0.000 1001.042"
 		orgRel="1"
-		rot="0.0000 0.9389 0.0000 -0.3440"
+		rot="-0.0203 0.9699 -0.0118 -0.2425"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object7467"
 		class="SgAnimatedModelNode"
-		org="3032.255 0.000 984.663"
+		org="3034.242 0.000 983.347"
 		orgRel="1"
-		rot="0.0000 0.9914 0.0000 -0.1305"
+		rot="-0.0020 0.9537 -0.0107 -0.3007"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object7468"
 		class="SgAnimatedModelNode"
-		org="3020.335 0.000 969.280"
+		org="3018.927 0.000 968.560"
 		orgRel="1"
 		rot="0.0000 0.8920 0.0000 -0.4520"
 		id="arena_barricade10"
@@ -11286,7 +11258,7 @@
 	<Node
 		name="Object7469"
 		class="SgAnimatedModelNode"
-		org="3001.478 0.000 962.909"
+		org="2999.021 0.000 962.191"
 		orgRel="1"
 		rot="0.0000 0.7446 0.0000 -0.6675"
 		id="arena_barricade10"
@@ -13123,16 +13095,16 @@
 	<Node
 		name="Object7969"
 		class="SgAnimatedModelNode"
-		org="1855.983 0.000 2100.706"
+		org="1856.947 0.000 2099.371"
 		orgRel="1"
-		rot="-0.0444 -0.8875 -0.0778 0.4520"
+		rot="0.0089 -0.8951 -0.0628 0.4414"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object7970"
 		class="SgAnimatedModelNode"
-		org="1838.689 0.000 2090.515"
+		org="1838.965 0.000 2088.697"
 		orgRel="1"
 		rot="0.0004 -0.8491 -0.0331 0.5272"
 		id="arena_barricade10"
@@ -13141,34 +13113,34 @@
 	<Node
 		name="Object7971"
 		class="SgAnimatedModelNode"
-		org="1819.202 0.325 2084.332"
+		org="1818.839 0.325 2082.840"
 		orgRel="1"
-		rot="-0.0040 -0.7716 -0.0329 0.6352"
+		rot="-0.0012 -0.7718 -0.0295 0.6352"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object7972"
 		class="SgAnimatedModelNode"
-		org="1798.560 0.176 2082.803"
+		org="1797.631 0.176 2080.598"
 		orgRel="1"
-		rot="-0.0318 -0.7019 -0.0571 0.7093"
+		rot="-0.0154 -0.7015 -0.0395 0.7114"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object7973"
 		class="SgAnimatedModelNode"
-		org="1778.514 -0.995 2085.128"
+		org="1776.823 -0.995 2086.815"
 		orgRel="1"
-		rot="-0.0369 -0.6340 -0.0539 0.7705"
+		rot="-0.0539 -0.6156 -0.0703 0.7831"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object7974"
 		class="SgAnimatedModelNode"
-		org="3060.724 0.000 868.791"
+		org="3062.277 0.000 869.713"
 		orgRel="1"
 		rot="-0.0076 -0.8857 0.0076 0.4640"
 		id="arena_barricade10"
@@ -13179,25 +13151,25 @@
 		class="SgAnimatedModelNode"
 		org="3043.602 -0.709 858.785"
 		orgRel="1"
-		rot="0.0482 -0.8507 0.0726 0.5182"
+		rot="0.0425 -0.8515 0.0633 0.5187"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object7976"
 		class="SgAnimatedModelNode"
-		org="3025.595 -0.234 850.349"
+		org="3024.118 -0.234 850.033"
 		orgRel="1"
-		rot="0.0893 -0.8229 0.0957 0.5528"
+		rot="0.0539 -0.8110 0.0394 0.5812"
 		id="arena_barricade10"
 		ndmAction="0" />
 
 	<Node
 		name="Object7977"
 		class="SgAnimatedModelNode"
-		org="3007.056 -0.234 842.528"
+		org="2999.689 -0.234 845.711"
 		orgRel="1"
-		rot="0.0641 -0.8252 0.0788 0.5555"
+		rot="0.0413 -0.7574 0.0630 0.6486"
 		id="arena_barricade10"
 		ndmAction="0" />
 

--- a/patch/maps/r3m2/dynamicscene.xml
+++ b/patch/maps/r3m2/dynamicscene.xml
@@ -2387,8 +2387,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="540.859 268.173 1873.293"
-		Rot="0.000 0.009 0.000 1.000"
-		NodeScale="1.060" />
+		Rot="0.000 0.009 0.000 1.000" />
 
 	<Object
 		Name="r3_tropicpalma341"
@@ -2506,8 +2505,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="663.333 323.905 1683.541"
-		Rot="0.000 -0.998 0.000 0.061"
-		NodeScale="1.060" />
+		Rot="0.000 -0.998 0.000 0.061" />
 
 	<Object
 		Name="r3_tropicpalma156"
@@ -2689,8 +2687,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="352.304 329.412 1965.903"
-		Rot="0.000 -0.276 0.000 0.961"
-		NodeScale="1.150" />
+		Rot="0.000 -0.276 0.000 0.961" />
 
 	<Object
 		Name="r3_tropicpalma279"
@@ -2737,8 +2734,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="461.041 347.434 2332.296"
-		Rot="0.000 0.070 0.000 0.998"
-		NodeScale="1.150" />
+		Rot="0.000 0.070 0.000 0.998" />
 
 	<Object
 		Name="r3_tropicpalma285"
@@ -2953,8 +2949,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="341.391 390.420 1730.584"
-		Rot="0.000 -0.989 0.000 0.148"
-		NodeScale="1.150" />
+		Rot="0.000 -0.989 0.000 0.148" />
 
 	<Object
 		Name="r3_tropicpalma3112"
@@ -3102,8 +3097,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="476.845 383.473 2577.404"
-		Rot="0.000 0.940 0.000 0.342"
-		NodeScale="1.150" />
+		Rot="0.000 0.940 0.000 0.342" />
 
 	<Object
 		Name="r3_tropicpalma3131"
@@ -3126,168 +3120,147 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="443.031 380.059 2560.394"
-		Rot="0.000 -0.500 0.000 0.866"
-		NodeScale="1.050" />
+		Rot="0.000 -0.500 0.000 0.866" />
 
 	<Object
 		Name="wood_fence1134"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="701.879 291.112 2284.090"
-		Rot="0.000 -0.156 0.000 0.988"
-		NodeScale="1.060" />
+		Rot="0.000 -0.156 0.000 0.988" />
 
 	<Object
 		Name="wood_fence1135"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="712.100 291.112 2287.326"
-		Rot="0.000 -0.156 0.000 0.988"
-		NodeScale="1.060" />
+		Rot="0.000 -0.156 0.000 0.988" />
 
 	<Object
 		Name="wood_fence1136"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="721.979 291.112 2291.472"
-		Rot="0.000 -0.248 0.000 0.969"
-		NodeScale="1.060" />
+		Rot="0.000 -0.248 0.000 0.969" />
 
 	<Object
 		Name="wood_fence1137"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="731.415 291.112 2296.538"
-		Rot="0.000 -0.248 0.000 0.969"
-		NodeScale="1.060" />
+		Rot="0.000 -0.248 0.000 0.969" />
 
 	<Object
 		Name="wood_fence1138"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="741.148 291.112 2300.744"
-		Rot="0.000 -0.163 0.000 0.987"
-		NodeScale="1.060" />
+		Rot="0.000 -0.163 0.000 0.987" />
 
 	<Object
 		Name="wood_fence1139"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="751.013 291.112 2304.793"
-		Rot="0.000 -0.236 0.000 0.972"
-		NodeScale="1.060" />
+		Rot="0.000 -0.236 0.000 0.972" />
 
 	<Object
 		Name="wood_fence1140"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="760.370 291.112 2310.012"
-		Rot="0.000 -0.276 0.000 0.961"
-		NodeScale="1.060" />
+		Rot="0.000 -0.276 0.000 0.961" />
 
 	<Object
 		Name="wood_fence1141"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="776.791 291.112 2322.045"
-		Rot="0.000 -0.276 0.000 0.961"
-		NodeScale="1.060" />
+		Rot="0.000 -0.276 0.000 0.961" />
 
 	<Object
 		Name="wood_fence1142"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="785.829 291.112 2327.818"
-		Rot="0.000 -0.290 0.000 0.957"
-		NodeScale="1.060" />
+		Rot="0.000 -0.290 0.000 0.957" />
 
 	<Object
 		Name="wood_fence1143"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="794.522 291.112 2334.006"
-		Rot="0.000 -0.319 0.000 0.948"
-		NodeScale="1.060" />
+		Rot="0.000 -0.319 0.000 0.948" />
 
 	<Object
 		Name="wood_fence1144"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="803.647 291.112 2336.538"
-		Rot="0.000 0.085 0.000 0.996"
-		NodeScale="1.060" />
+		Rot="0.000 0.085 0.000 0.996" />
 
 	<Object
 		Name="wood_fence1145"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="814.225 291.112 2335.144"
-		Rot="0.000 0.033 0.000 0.999"
-		NodeScale="1.060" />
+		Rot="0.000 0.033 0.000 0.999" />
 
 	<Object
 		Name="wood_fence1146"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="824.902 291.112 2335.189"
-		Rot="0.000 -0.102 0.000 0.995"
-		NodeScale="1.060" />
+		Rot="0.000 -0.102 0.000 0.995" />
 
 	<Object
 		Name="wood_fence1147"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="835.697 291.112 2335.083"
-		Rot="0.000 0.109 0.000 0.994"
-		NodeScale="1.060" />
+		Rot="0.000 0.109 0.000 0.994" />
 
 	<Object
 		Name="wood_fence1148"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="869.151 291.112 2334.123"
-		Rot="0.000 0.907 0.000 0.421"
-		NodeScale="1.060" />
+		Rot="0.000 0.907 0.000 0.421" />
 
 	<Object
 		Name="wood_fence1149"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="877.449 291.112 2340.716"
-		Rot="0.000 0.971 0.000 0.238"
-		NodeScale="1.060" />
+		Rot="0.000 0.971 0.000 0.238" />
 
 	<Object
 		Name="wood_fence1150"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="886.952 291.112 2345.585"
-		Rot="0.000 0.971 0.000 0.238"
-		NodeScale="1.060" />
+		Rot="0.000 0.971 0.000 0.238" />
 
 	<Object
 		Name="wood_fence1151"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="894.916 291.112 2352.203"
-		Rot="0.000 0.899 0.000 0.438"
-		NodeScale="1.060" />
+		Rot="0.000 0.899 0.000 0.438" />
 
 	<Object
 		Name="wood_fence1152"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="899.643 291.302 2361.786"
-		Rot="0.000 0.797 0.000 0.604"
-		NodeScale="1.060" />
+		Rot="0.000 0.797 0.000 0.604" />
 
 	<Object
 		Name="r3_tropicpalma1153"
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="1088.127 268.000 2167.941"
-		Rot="0.000 -0.026 0.000 1.000"
-		NodeScale="1.060" />
+		Rot="0.000 -0.026 0.000 1.000" />
 
 	<Object
 		Name="r3_tropicpalma1154"
@@ -3396,8 +3369,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="1472.276 279.999 1747.430"
-		Rot="0.000 0.174 0.000 0.985"
-		NodeScale="1.060" />
+		Rot="0.000 0.174 0.000 0.985" />
 
 	<Object
 		Name="r3_tropicpalma3168"
@@ -3508,8 +3480,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="1176.888 331.013 1657.333"
-		Rot="0.000 -0.415 0.000 0.910"
-		NodeScale="1.060" />
+		Rot="0.000 -0.415 0.000 0.910" />
 
 	<Object
 		Name="r3_tropicpalma3182"
@@ -3692,8 +3663,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="1296.051 303.000 2172.208"
-		Rot="0.000 -0.749 0.000 0.663"
-		NodeScale="1.050" />
+		Rot="0.000 -0.749 0.000 0.663" />
 
 	<Object
 		Name="r3_tropicpalma1205"
@@ -3756,8 +3726,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="1107.025 313.087 1674.062"
-		Rot="0.000 0.191 0.000 0.982"
-		NodeScale="1.060" />
+		Rot="0.000 0.191 0.000 0.982" />
 
 	<Object
 		Name="r3_tropicpalma1213"
@@ -3780,8 +3749,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="1001.523 318.000 1830.201"
-		Rot="0.000 0.843 0.000 0.537"
-		NodeScale="1.050" />
+		Rot="0.000 0.843 0.000 0.537" />
 
 	<Object
 		Name="r3_tropicpalma3216"
@@ -3820,8 +3788,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="1351.305 303.009 1982.776"
-		Rot="0.000 0.399 0.000 0.917"
-		NodeScale="1.150" />
+		Rot="0.000 0.399 0.000 0.917" />
 
 	<Object
 		Name="r3_tropicpalma3221"
@@ -3868,8 +3835,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="1585.646 323.354 1997.019"
-		Rot="0.000 0.998 0.000 0.070"
-		NodeScale="1.060" />
+		Rot="0.000 0.998 0.000 0.070" />
 
 	<Object
 		Name="r3_tropicpalma3227"
@@ -3932,8 +3898,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="1814.645 313.488 1745.559"
-		Rot="0.000 -0.749 0.000 0.663"
-		NodeScale="1.050" />
+		Rot="0.000 -0.749 0.000 0.663" />
 
 	<Object
 		Name="r3_tropicpalma3235"
@@ -3988,8 +3953,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="1858.428 306.116 1544.990"
-		Rot="0.000 -0.242 0.000 0.970"
-		NodeScale="1.050" />
+		Rot="0.000 -0.242 0.000 0.970" />
 
 	<Object
 		Name="r3_tropicpalma3242"
@@ -4092,8 +4056,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="1773.676 303.031 2246.412"
-		Rot="0.000 0.581 0.000 0.814"
-		NodeScale="1.060" />
+		Rot="0.000 0.581 0.000 0.814" />
 
 	<Object
 		Name="r3_tropicpalma1255"
@@ -4372,8 +4335,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="1226.234 320.151 2938.535"
-		Rot="0.000 -0.994 0.000 0.105"
-		NodeScale="1.050" />
+		Rot="0.000 -0.994 0.000 0.105" />
 
 	<Object
 		Name="r3_tropicpalma2290"
@@ -4476,16 +4438,14 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="1094.253 312.482 3006.942"
-		Rot="0.000 -0.656 0.000 0.755"
-		NodeScale="1.060" />
+		Rot="0.000 -0.656 0.000 0.755" />
 
 	<Object
 		Name="r3_tropicpalma2303"
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="1142.707 333.832 2943.185"
-		Rot="0.000 0.920 0.000 0.391"
-		NodeScale="1.150" />
+		Rot="0.000 0.920 0.000 0.391" />
 
 	<Object
 		Name="r3_tropicpalma2304"
@@ -4612,8 +4572,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="153.934 340.734 3234.228"
-		Rot="0.000 -0.866 0.000 0.500"
-		NodeScale="1.150" />
+		Rot="0.000 -0.866 0.000 0.500" />
 
 	<Object
 		Name="r3_tropicpalma2320"
@@ -4914,16 +4873,14 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="1662.591 305.415 3294.122"
-		Rot="0.000 0.914 0.000 0.407"
-		NodeScale="1.050" />
+		Rot="0.000 0.914 0.000 0.407" />
 
 	<Object
 		Name="r3_tropicpalma2358"
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="1698.777 303.180 3280.644"
-		Rot="0.000 -0.477 0.000 0.879"
-		NodeScale="1.050" />
+		Rot="0.000 -0.477 0.000 0.879" />
 
 	<Object
 		Name="r3_tropicpalma2359"
@@ -5018,8 +4975,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="1145.147 307.944 1273.876"
-		Rot="0.000 0.165 0.000 0.986"
-		NodeScale="1.060" />
+		Rot="0.000 0.165 0.000 0.986" />
 
 	<Object
 		Name="r3_tropicpalma1371"
@@ -5160,8 +5116,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="3255.052 266.771 322.939"
-		Rot="0.000 -0.799 0.000 0.602"
-		NodeScale="1.060" />
+		Rot="0.000 -0.799 0.000 0.602" />
 
 	<Object
 		Name="r3_tropicpalma3389"
@@ -5184,8 +5139,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="3287.000 257.487 240.537"
-		Rot="0.000 -0.691 0.000 0.722"
-		NodeScale="1.050" />
+		Rot="0.000 -0.691 0.000 0.722" />
 
 	<Object
 		Name="r3_tropicpalma3392"
@@ -5271,8 +5225,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="3354.886 305.528 135.320"
-		Rot="0.000 -0.669 0.000 0.743"
-		NodeScale="1.060" />
+		Rot="0.000 -0.669 0.000 0.743" />
 
 	<Object
 		Name="r3_tropicpalma3403"
@@ -5495,160 +5448,140 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3728.935 279.086 818.625"
-		Rot="0.000 -0.063 0.000 0.998"
-		NodeScale="1.150" />
+		Rot="0.000 -0.063 0.000 0.998" />
 
 	<Object
 		Name="wood_fence1431"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3717.709 278.000 817.402"
-		Rot="0.000 -0.063 0.000 0.998"
-		NodeScale="1.150" />
+		Rot="0.000 -0.063 0.000 0.998" />
 
 	<Object
 		Name="wood_fence1432"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3706.433 278.000 816.143"
-		Rot="0.000 -0.063 0.000 0.998"
-		NodeScale="1.150" />
+		Rot="0.000 -0.063 0.000 0.998" />
 
 	<Object
 		Name="wood_fence1433"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3695.321 278.000 814.024"
-		Rot="0.000 -0.128 0.000 0.992"
-		NodeScale="1.150" />
+		Rot="0.000 -0.128 0.000 0.992" />
 
 	<Object
 		Name="wood_fence1434"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3684.049 278.000 811.930"
-		Rot="0.000 -0.063 0.000 0.998"
-		NodeScale="1.150" />
+		Rot="0.000 -0.063 0.000 0.998" />
 
 	<Object
 		Name="wood_fence1435"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3672.921 278.000 810.593"
-		Rot="0.000 -0.063 0.000 0.998"
-		NodeScale="1.150" />
+		Rot="0.000 -0.063 0.000 0.998" />
 
 	<Object
 		Name="wood_fence1436"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3661.616 278.000 811.024"
-		Rot="0.000 0.079 0.000 0.997"
-		NodeScale="1.150" />
+		Rot="0.000 0.079 0.000 0.997" />
 
 	<Object
 		Name="wood_fence1437"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3650.294 278.000 811.253"
-		Rot="0.000 -0.063 0.000 0.998"
-		NodeScale="1.150" />
+		Rot="0.000 -0.063 0.000 0.998" />
 
 	<Object
 		Name="wood_fence1438"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3638.724 278.000 810.701"
-		Rot="0.000 0.006 0.000 1.000"
-		NodeScale="1.150" />
+		Rot="0.000 0.006 0.000 1.000" />
 
 	<Object
 		Name="wood_fence1439"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3627.156 278.000 811.630"
-		Rot="0.000 0.063 0.000 0.998"
-		NodeScale="1.150" />
+		Rot="0.000 0.063 0.000 0.998" />
 
 	<Object
 		Name="wood_fence1440"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3616.432 278.000 814.407"
-		Rot="0.000 0.178 0.000 0.984"
-		NodeScale="1.150" />
+		Rot="0.000 0.178 0.000 0.984" />
 
 	<Object
 		Name="wood_fence1441"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3604.752 278.000 816.693"
-		Rot="0.000 0.026 0.000 1.000"
-		NodeScale="1.150" />
+		Rot="0.000 0.026 0.000 1.000" />
 
 	<Object
 		Name="wood_fence1442"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3593.238 278.000 816.934"
-		Rot="0.000 -0.026 0.000 1.000"
-		NodeScale="1.150" />
+		Rot="0.000 -0.026 0.000 1.000" />
 
 	<Object
 		Name="wood_fence1443"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3581.654 278.000 816.473"
-		Rot="0.000 -0.026 0.000 1.000"
-		NodeScale="1.150" />
+		Rot="0.000 -0.026 0.000 1.000" />
 
 	<Object
 		Name="wood_fence1444"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3570.302 278.000 816.034"
-		Rot="0.000 -0.026 0.000 1.000"
-		NodeScale="1.150" />
+		Rot="0.000 -0.026 0.000 1.000" />
 
 	<Object
 		Name="wood_fence1445"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3558.642 278.000 815.542"
-		Rot="0.000 -0.026 0.000 1.000"
-		NodeScale="1.150" />
+		Rot="0.000 -0.026 0.000 1.000" />
 
 	<Object
 		Name="wood_fence1446"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3547.329 278.000 817.884"
-		Rot="0.000 0.208 0.000 0.978"
-		NodeScale="1.150" />
+		Rot="0.000 0.208 0.000 0.978" />
 
 	<Object
 		Name="wood_fence1447"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3537.787 278.000 823.585"
-		Rot="0.000 0.309 0.000 0.951"
-		NodeScale="1.150" />
+		Rot="0.000 0.309 0.000 0.951" />
 
 	<Object
 		Name="wood_fence1448"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3529.797 278.000 831.069"
-		Rot="0.000 0.399 0.000 0.917"
-		NodeScale="1.150" />
+		Rot="0.000 0.399 0.000 0.917" />
 
 	<Object
 		Name="wood_fence1449"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="3520.124 278.000 836.363"
-		Rot="0.000 0.135 0.000 0.991"
-		NodeScale="1.150" />
+		Rot="0.000 0.135 0.000 0.991" />
 
 	<Object
 		Name="r3_tropicpalma3450"
@@ -5878,8 +5811,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="3599.995 329.000 1496.613"
-		Rot="0.000 0.875 0.000 0.485"
-		NodeScale="1.050" />
+		Rot="0.000 0.875 0.000 0.485" />
 
 	<Object
 		Name="r3_tropicpalma2479"
@@ -5934,8 +5866,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="2944.042 355.681 1456.380"
-		Rot="0.000 0.853 0.000 0.523"
-		NodeScale="1.060" />
+		Rot="0.000 0.853 0.000 0.523" />
 
 	<Object
 		Name="r3_tropicpalma2486"
@@ -5974,8 +5905,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="2984.458 307.223 896.628"
-		Rot="0.000 0.688 0.000 0.725"
-		NodeScale="1.050" />
+		Rot="0.000 0.688 0.000 0.725" />
 
 	<Object
 		Name="r3_tropicpalma2491"
@@ -6134,8 +6064,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="3879.656 403.439 1335.573"
-		Rot="0.000 -0.920 0.000 0.391"
-		NodeScale="1.060" />
+		Rot="0.000 -0.920 0.000 0.391" />
 
 	<Object
 		Name="r3_tropicpalma1511"
@@ -6696,8 +6625,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="616.205 337.009 3824.644"
-		Rot="0.000 -0.208 0.000 0.978"
-		NodeScale="1.050" />
+		Rot="0.000 -0.208 0.000 0.978" />
 
 	<Object
 		Name="r3_tropicpalma2600"
@@ -6752,40 +6680,35 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="1251.155 320.827 2670.159"
-		Rot="0.000 0.896 0.000 0.444"
-		NodeScale="0.905" />
+		Rot="0.000 0.896 0.000 0.444" />
 
 	<Object
 		Name="wood_fence1607"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="1244.270 321.406 2663.930"
-		Rot="0.000 0.950 0.000 0.313"
-		NodeScale="0.905" />
+		Rot="0.000 0.950 0.000 0.313" />
 
 	<Object
 		Name="wood_fence1608"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="1235.874 321.035 2659.248"
-		Rot="0.000 0.987 0.000 0.163"
-		NodeScale="0.905" />
+		Rot="0.000 0.987 0.000 0.163" />
 
 	<Object
 		Name="wood_fence1609"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="1227.379 320.528 2657.492"
-		Rot="0.000 0.999 0.000 0.037"
-		NodeScale="0.905" />
+		Rot="0.000 0.999 0.000 0.037" />
 
 	<Object
 		Name="wood_fence1610"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="1218.585 320.034 2657.678"
-		Rot="0.000 -0.998 0.000 0.057"
-		NodeScale="0.905" />
+		Rot="0.000 -0.998 0.000 0.057" />
 
 	<Object
 		Name="wood_fence2611"
@@ -6929,8 +6852,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="2887.019 260.676 2136.286"
-		Rot="0.000 0.819 0.000 0.574"
-		NodeScale="1.060" />
+		Rot="0.000 0.819 0.000 0.574" />
 
 	<Object
 		Name="r3_tropicpalma3631"
@@ -7017,8 +6939,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="2503.875 314.933 1030.853"
-		Rot="0.000 -0.940 0.000 0.342"
-		NodeScale="1.060" />
+		Rot="0.000 -0.940 0.000 0.342" />
 
 	<Object
 		Name="r3_tropicpalma2642"
@@ -7125,8 +7046,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="1320.148 312.670 933.837"
-		Rot="0.000 -0.199 0.000 0.980"
-		NodeScale="1.060" />
+		Rot="0.000 -0.199 0.000 0.980" />
 
 	<Object
 		Name="r3_tropicpalma3657"
@@ -7141,8 +7061,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="1015.846 355.000 992.931"
-		Rot="0.000 0.026 0.000 1.000"
-		NodeScale="1.050" />
+		Rot="0.000 0.026 0.000 1.000" />
 
 	<Object
 		Name="r3_tropicpalma3659"
@@ -7380,8 +7299,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="1448.222 371.354 816.267"
-		Rot="0.000 -0.656 0.000 0.755"
-		NodeScale="1.150" />
+		Rot="0.000 -0.656 0.000 0.755" />
 
 	<Object
 		Name="r3_tropicpalma3689"
@@ -7436,8 +7354,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="1880.060 360.106 960.697"
-		Rot="0.000 0.052 0.000 0.999"
-		NodeScale="1.050" />
+		Rot="0.000 0.052 0.000 0.999" />
 
 	<Object
 		Name="r3_tropicpalma1696"
@@ -7563,8 +7480,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="2592.280 299.493 1311.907"
-		Rot="0.000 0.895 0.000 0.446"
-		NodeScale="1.060" />
+		Rot="0.000 0.895 0.000 0.446" />
 
 	<Object
 		Name="r3_tropicpalma2712"
@@ -7698,8 +7614,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="2983.061 356.551 1959.293"
-		Rot="0.000 -0.899 0.000 0.438"
-		NodeScale="1.150" />
+		Rot="0.000 -0.899 0.000 0.438" />
 
 	<Object
 		Name="r3_tropicpalma1729"
@@ -7730,8 +7645,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="3112.106 341.306 2056.172"
-		Rot="0.000 -0.259 0.000 0.966"
-		NodeScale="1.050" />
+		Rot="0.000 -0.259 0.000 0.966" />
 
 	<Object
 		Name="r3_tropicpalma1733"
@@ -7928,48 +7842,42 @@
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="778.979 291.112 2072.159"
-		Rot="0.000 -0.100 0.000 0.995"
-		NodeScale="0.910" />
+		Rot="0.000 -0.100 0.000 0.995" />
 
 	<Object
 		Name="wood_fence1760"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="770.249 291.112 2069.413"
-		Rot="0.000 -0.201 0.000 0.980"
-		NodeScale="0.910" />
+		Rot="0.000 -0.201 0.000 0.980" />
 
 	<Object
 		Name="wood_fence1761"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="761.711 291.112 2066.381"
-		Rot="0.000 -0.152 0.000 0.988"
-		NodeScale="0.910" />
+		Rot="0.000 -0.152 0.000 0.988" />
 
 	<Object
 		Name="wood_fence1762"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="752.819 291.112 2064.377"
-		Rot="0.000 -0.079 0.000 0.997"
-		NodeScale="0.910" />
+		Rot="0.000 -0.079 0.000 0.997" />
 
 	<Object
 		Name="wood_fence1763"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="743.911 291.112 2062.211"
-		Rot="0.000 -0.165 0.000 0.986"
-		NodeScale="0.910" />
+		Rot="0.000 -0.165 0.000 0.986" />
 
 	<Object
 		Name="wood_fence1764"
 		Belong="-1"
 		Prototype="Breakable_WoodFence1"
 		Pos="735.184 291.112 2059.368"
-		Rot="0.000 -0.165 0.000 0.986"
-		NodeScale="0.910" />
+		Rot="0.000 -0.165 0.000 0.986" />
 
 	<Object
 		Name="r3_tropicpalma2765"
@@ -7982,8 +7890,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="95.449 367.466 3093.313"
-		Rot="0.000 0.350 0.000 0.937"
-		NodeScale="1.050" />
+		Rot="0.000 0.350 0.000 0.937" />
 
 	<Object
 		Name="r3_tropicpalma2767"
@@ -8077,8 +7984,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="224.583 396.038 2797.727"
-		Rot="0.000 0.438 0.000 0.899"
-		NodeScale="1.060" />
+		Rot="0.000 0.438 0.000 0.899" />
 
 	<Object
 		Name="r3_tropicpalma1779"
@@ -8213,8 +8119,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="73.047 399.855 3188.448"
-		Rot="0.000 -0.887 0.000 0.462"
-		NodeScale="1.060" />
+		Rot="0.000 -0.887 0.000 0.462" />
 
 	<Object
 		Name="r3_tropicpalma3796"
@@ -8301,8 +8206,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="388.179 385.974 3826.616"
-		Rot="0.000 -0.233 0.000 0.972"
-		NodeScale="1.050" />
+		Rot="0.000 -0.233 0.000 0.972" />
 
 	<Object
 		Name="r3_tropicpalma1807"
@@ -8317,8 +8221,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="396.962 385.908 3831.937"
-		Rot="0.000 0.749 0.000 0.663"
-		NodeScale="1.060" />
+		Rot="0.000 0.749 0.000 0.663" />
 
 	<Object
 		Name="r3_tropicpalma2809"
@@ -8500,8 +8403,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="305.820 408.459 3608.474"
-		Rot="0.000 0.943 0.000 0.334"
-		NodeScale="1.050" />
+		Rot="0.000 0.943 0.000 0.334" />
 
 	<Object
 		Name="r3_tropicpalma3832"
@@ -8620,8 +8522,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="225.553 366.642 3402.641"
-		Rot="0.000 -0.887 0.000 0.462"
-		NodeScale="1.060" />
+		Rot="0.000 -0.887 0.000 0.462" />
 
 	<Object
 		Name="r3_tropicpalma1847"
@@ -8652,8 +8553,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="370.376 304.370 3476.426"
-		Rot="0.000 -0.829 0.000 0.559"
-		NodeScale="1.150" />
+		Rot="0.000 -0.829 0.000 0.559" />
 
 	<Object
 		Name="r3_tropicpalma1851"
@@ -8732,8 +8632,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="400.485 329.000 3643.762"
-		Rot="0.000 -0.974 0.000 0.225"
-		NodeScale="1.060" />
+		Rot="0.000 -0.974 0.000 0.225" />
 
 	<Object
 		Name="r3_tropicpalma1861"
@@ -8836,8 +8735,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="840.143 266.838 3649.545"
-		Rot="0.000 0.139 0.000 0.990"
-		NodeScale="1.060" />
+		Rot="0.000 0.139 0.000 0.990" />
 
 	<Object
 		Name="r3_tropicpalma2874"
@@ -8867,8 +8765,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="956.321 311.036 3671.362"
-		Rot="0.000 -0.334 0.000 0.943"
-		NodeScale="1.060" />
+		Rot="0.000 -0.334 0.000 0.943" />
 
 	<Object
 		Name="r3_tropicpalma3878"
@@ -10599,8 +10496,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="2835.664 341.083 849.162"
-		Rot="0.000 -0.910 0.000 0.415"
-		NodeScale="1.060" />
+		Rot="0.000 -0.910 0.000 0.415" />
 
 	<Object
 		Name="r3_tropicpalma11095"
@@ -11053,8 +10949,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="2746.378 357.727 462.400"
-		Rot="0.000 0.250 0.000 0.968"
-		NodeScale="1.060" />
+		Rot="0.000 0.250 0.000 0.968" />
 
 	<Object
 		Name="r3_tropicpalma11152"
@@ -14660,8 +14555,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="3713.480 393.162 3586.410"
-		Rot="0.000 0.993 0.000 0.122"
-		NodeScale="1.150" />
+		Rot="0.000 0.993 0.000 0.122" />
 
 	<Object
 		Name="r3_tropicpalma11604"
@@ -15492,8 +15386,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="4034.702 432.170 2704.310"
-		Rot="0.000 0.843 0.000 0.537"
-		NodeScale="0.905" />
+		Rot="0.000 0.843 0.000 0.537" />
 
 	<Object
 		Name="r3_tropicpalma11708"
@@ -16388,8 +16281,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="1933.830 328.947 1312.770"
-		Rot="0.000 0.976 0.000 0.216"
-		NodeScale="1.060" />
+		Rot="0.000 0.976 0.000 0.216" />
 
 	<Object
 		Name="r3_tropicpalma21820"
@@ -17476,8 +17368,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="1380.238 340.978 3326.718"
-		Rot="0.000 -0.044 0.000 0.999"
-		NodeScale="1.150" />
+		Rot="0.000 -0.044 0.000 0.999" />
 
 	<Object
 		Name="r3_tropicpalma11956"
@@ -18452,8 +18343,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="252.645 372.146 2737.117"
-		Rot="0.000 0.974 0.000 0.225"
-		NodeScale="0.905" />
+		Rot="0.000 0.974 0.000 0.225" />
 
 	<Object
 		Name="r3_tropicpalma12078"
@@ -19063,8 +18953,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="2442.573 277.724 889.876"
-		Rot="0.000 -0.959 0.000 0.284"
-		NodeScale="1.150" />
+		Rot="0.000 -0.959 0.000 0.284" />
 
 	<Object
 		Name="r3_tropicpalma12157"
@@ -19079,8 +18968,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="2392.749 292.470 768.759"
-		Rot="0.000 0.990 0.000 0.139"
-		NodeScale="1.150" />
+		Rot="0.000 0.990 0.000 0.139" />
 
 	<Object
 		Name="r3_tropicpalma32159"
@@ -19183,8 +19071,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="3393.195 276.320 734.025"
-		Rot="0.000 0.026 0.000 1.000"
-		NodeScale="1.050" />
+		Rot="0.000 0.026 0.000 1.000" />
 
 	<Object
 		Name="r3_tropicpalma22172"
@@ -19239,8 +19126,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="943.970 264.029 3180.110"
-		Rot="0.000 -0.990 0.000 0.139"
-		NodeScale="1.060" />
+		Rot="0.000 -0.990 0.000 0.139" />
 
 	<Object
 		Name="r3_tropicpalma22179"
@@ -19383,8 +19269,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma3_dyn"
 		Pos="490.024 262.603 3298.398"
-		Rot="0.000 -0.970 0.000 0.242"
-		NodeScale="1.060" />
+		Rot="0.000 -0.970 0.000 0.242" />
 
 	<Object
 		Name="r3_tropicpalma32197"
@@ -19469,8 +19354,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="2023.011 262.535 1611.362"
-		Rot="0.000 -0.887 0.000 0.462"
-		NodeScale="1.060" />
+		Rot="0.000 -0.887 0.000 0.462" />
 
 	<Object
 		Name="r3_tropicpalma12208"
@@ -19493,8 +19377,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="2139.735 263.596 2011.903"
-		Rot="0.000 0.113 0.000 0.994"
-		NodeScale="1.060" />
+		Rot="0.000 0.113 0.000 0.994" />
 
 	<Object
 		Name="r3_tropicpalma32211"
@@ -19691,8 +19574,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="3590.135 255.845 2456.167"
-		Rot="0.000 0.995 0.000 0.096"
-		NodeScale="1.050" />
+		Rot="0.000 0.995 0.000 0.096" />
 
 	<Object
 		Name="r3_tropicpalma22236"
@@ -19707,8 +19589,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="3375.970 263.478 2266.687"
-		Rot="0.000 -0.853 0.000 0.523"
-		NodeScale="1.150" />
+		Rot="0.000 -0.853 0.000 0.523" />
 
 	<Object
 		Name="r3_tropicpalma22238"
@@ -19961,8 +19842,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="3366.961 257.194 2968.757"
-		Rot="0.000 0.945 0.000 0.326"
-		NodeScale="1.050" />
+		Rot="0.000 0.945 0.000 0.326" />
 
 	<Object
 		Name="r3_tropicpalma12270"
@@ -20101,8 +19981,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="2760.457 258.000 2776.480"
-		Rot="0.000 -0.588 0.000 0.809"
-		NodeScale="1.060" />
+		Rot="0.000 -0.588 0.000 0.809" />
 
 	<Object
 		Name="r3_tropicpalma32288"
@@ -20149,16 +20028,14 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="2866.213 262.697 2951.345"
-		Rot="0.000 -0.588 0.000 0.809"
-		NodeScale="1.060" />
+		Rot="0.000 -0.588 0.000 0.809" />
 
 	<Object
 		Name="r3_tropicpalma12294"
 		Belong="-1"
 		Prototype="r3_tropicpalma1_dyn"
 		Pos="2691.482 258.000 2868.183"
-		Rot="0.000 -0.588 0.000 0.809"
-		NodeScale="1.060" />
+		Rot="0.000 -0.588 0.000 0.809" />
 
 	<Object
 		Name="r3_tropicpalma22295"
@@ -20267,8 +20144,7 @@
 		Belong="-1"
 		Prototype="r3_tropicpalma2_dyn"
 		Pos="2837.654 255.821 3050.040"
-		Rot="0.000 -0.688 0.000 0.725"
-		NodeScale="1.060" />
+		Rot="0.000 -0.688 0.000 0.725" />
 
 	<Object
 		Name="r3_tropicpalma22309"


### PR DESCRIPTION
It fixes scale of 'breakable breakable objects' like signs and posters, that change their size when break.
Fixed:
slightly randomed barrels in r1m2 (you probably wouldn't see this)
posters, road signs in r1m2, r1m3, r1m4
wood fences in r2m2, r3m2