### PR TITLE
Removed unused items from r2m1 and r3m1 servers

### DIFF
--- a/patch/maps/r2m1/servers.xml
+++ b/patch/maps/r2m1/servers.xml
@@ -2116,18 +2116,6 @@
 
 <!-- For Effect -->
 		<Item 
-			id="barrel3_dyn" 
-			file="data\models\AnimModels.xml"/>
-
-		<Item 
-			id="barrel1_dyn" 
-			file="data\models\AnimModels.xml"/>
-
-		<Item 
-			id="shell" 
-			file="data\models\AnimModels.xml"/>
-
-		<Item 
 			id="barrel_debris" 
 			file="data\models\AnimModels.xml"/>
 

--- a/patch/maps/r3m1/servers.xml
+++ b/patch/maps/r3m1/servers.xml
@@ -168,10 +168,6 @@
 		<Item 
 			id="kustarnik2" 
 			file="data\models\AnimModels.xml"/>
-			
-		<Item 
-			id="barrel3_dyn" 
-			file="data\models\AnimModels.xml"/>
 
 		<!-- goods -->
 		<Item 

--- a/remaster/hd_vehicle_models/data/maps/r2m1/servers.xml
+++ b/remaster/hd_vehicle_models/data/maps/r2m1/servers.xml
@@ -2120,18 +2120,6 @@
 
 <!-- For Effect -->
 		<Item 
-			id="barrel3_dyn" 
-			file="data\models\AnimModels.xml"/>
-
-		<Item 
-			id="barrel1_dyn" 
-			file="data\models\AnimModels.xml"/>
-
-		<Item 
-			id="shell" 
-			file="data\models\AnimModels.xml"/>
-
-		<Item 
 			id="barrel_debris" 
 			file="data\models\AnimModels.xml"/>
 

--- a/remaster/hd_vehicle_models/data/maps/r3m1/servers.xml
+++ b/remaster/hd_vehicle_models/data/maps/r3m1/servers.xml
@@ -168,10 +168,6 @@
 		<Item 
 			id="kustarnik2" 
 			file="data\models\AnimModels.xml"/>
-			
-		<Item 
-			id="barrel3_dyn" 
-			file="data\models\AnimModels.xml"/>
 
 		<!-- goods -->
 		<Item 


### PR DESCRIPTION
This is tricky one.

Кароч, суть такова. В логе было вот это: 
```
E serverAnimatedModel.cpp[0627]24/01 11:29:08 ServerAnimatedModels: cannot read file: file:data\models\AnimModels.xml id = barrel3_dyn
E serverAnimatedModel.cpp[0627]24/01 11:29:08 ServerAnimatedModels: cannot read file: file:data\models\AnimModels.xml id = barrel1_dyn
E serverAnimatedModel.cpp[0627]24/01 11:29:08 ServerAnimatedModels: cannot read file: file:data\models\AnimModels.xml id = shell
```
Поиск по файлам дал следующие результаты:
в animmodels этих объектов нет, значит их не существует физически
однако для каких-то psys эффектов они прописаны, но сами эти эффекты не используются (т.к. если бы использовались, то в логе было бы насрано + ящики были бы непосредственно в игре) или используются оооочень редко в каких-то суперспецифических случаях.
Так что я решил их просто выпилить из servers тех карт, где они прописаны (кстати, тот факт, что они прописаны не во все карты, тоже отношу к свидетельству того, что эффекты с ними не используются нигде)