### PR TITLE
Added removing old Lisa car at the end of the cutscene in r3m1

### DIFF
--- a/patch/maps/r3m1/cinematriggers.xml
+++ b/patch/maps/r3m1/cinematriggers.xml
@@ -1288,6 +1288,9 @@
 			FVehicle:Remove()
 		end
 
+		local lcar = getObj("LisaInCar")
+		if lcar then lcar:Remove() end
+
 		local vehPlayer = GetPlayerVehicle()
 		if vehPlayer then
 			vehPlayer:SetExternalPathByName("player_path10")


### PR DESCRIPTION
Крч говоря, если играя по ветке с Лисой после битвы с краном в Либриуме **во время** перехода в Рощу Друидов как ёбнутый долбить по клавише `Esc`, то машина Лисы не удалится после неё (так как её удаление происходит в триггере с таймаутом 0.1, который из-за столь быстрого скипа сработать не успевает) и эта шмара продолжит ездить за игроком всю оставшуюся игру, из-за чего успешно задублируется в Вахате. 
Продублировал удаление её машины в финальный триггер катсцены, который срабатывает всегда, так что теперь такой проблемы нет.
Сейв для тестов: 
[00000009.zip](https://github.com/DeusExMachinaTeam/EM-CommunityPatch/files/10774194/00000009.zip)
