### PR TITLE
Fixed r1m4 storage quest logic, improved cutscene's duration

### DIFF
--- a/patch/if/diz/questinfoglobal.xml
+++ b/patch/if/diz/questinfoglobal.xml
@@ -219,7 +219,7 @@
 
 	<QuestInfo
 		questName="FreeExtremistLeader_Quest3_2"
-		briefDiz="Уничтожить головную машину"
+		briefDiz="Разоружить головную машину"
 		isMainQuest="0">
 		<Map
 			name="r1m4"

--- a/patch/maps/r1m4/camera_paths.xml
+++ b/patch/maps/r1m4/camera_paths.xml
@@ -70,8 +70,8 @@
 	</Path>
 
 	<Path Name = "Caravan_cam01">                         
-		<Point  coord="-2.000 3.500 -30.000"/>
-		<Point  coord="2.000 4.500 -40.000"/>
+		<Point  coord="-2.000 6.500 -30.000"/>
+		<Point  coord="2.000 7.500 -40.000"/>
 	</Path>
 
 	<Path Name = "Caravan_cam02">                         

--- a/patch/maps/r1m4/cinematriggers.xml
+++ b/patch/maps/r1m4/cinematriggers.xml
@@ -449,9 +449,9 @@
 			local Lider = GetEntityByName("LeaderCar_vehicle_0")
 			local LiderID = Lider:GetId()
 
-			FlyLinked( "Caravan_cam01", BandID , 10, 1, 0, vehPID, nil, true, nil, nil )
-			FlyLinked("Caravan_cam02", vehPID, 15, 0, 0, BandID, nil, true, nil, true )
-			FlyLinked("Caravan_cam03", LiderID, 10, 0, 1, LiderID, nil, true, nil, true )
+			FlyLinked( "Caravan_cam01", BandID , 14, 1, 0, vehPID, nil, true, nil, nil )
+			FlyLinked("Caravan_cam02", vehPID, 17, 0, 0, BandID, nil, true, nil, true )
+			FlyLinked("Caravan_cam03", LiderID, 18.5, 0, 1, LiderID, nil, true, nil, true )
 			StartCinematic()
 
 			AddCinematicMessage( 4, 1 )

--- a/patch/maps/r1m4/cinematriggers.xml
+++ b/patch/maps/r1m4/cinematriggers.xml
@@ -441,7 +441,7 @@
 			TActivate("trCaravan_cam03")
 			TActivate("trCaravan_Fade")
 			PlayCustomMusic("Passage01unloop")
-			RuleConsole("cinematic_spring_coeff 3.0")
+			RuleConsole("cinematic_spring_coeff 6.0")
 
 			local Band = GetEntityByName("LeaderGuardTeam_vehicle_0")
 			local BandID = Band:GetId()

--- a/patch/maps/r1m4/dynamicscene.xml
+++ b/patch/maps/r1m4/dynamicscene.xml
@@ -3339,8 +3339,8 @@
 			Name="barricade7_GwG16_Child2"
 			Belong="1005"
 			Prototype="staticAutoGun08"
-			Pos="2560.191 249.011 2479.885"
-			Rot="0.000 -0.225 0.000 0.974">
+			Pos="2552.737 248.655 2399.661"
+			Rot="0.000 0.212 0.000 0.977">
 			<Parts />
 		</Object>
 
@@ -3348,8 +3348,8 @@
 			Name="barricade7_GwG16_Child3"
 			Belong="1005"
 			Prototype="staticAutoGun08"
-			Pos="2570.976 249.416 2485.146"
-			Rot="0.000 -0.225 0.000 0.974">
+			Pos="2563.656 248.706 2394.683"
+			Rot="0.000 0.212 0.000 0.977">
 			<Parts />
 		</Object>
 	</Object>
@@ -30188,8 +30188,8 @@
 		Name="sack_wall13576"
 		Belong="-1"
 		Prototype="Breakable_SackWall1"
-		Pos="2565.583 249.284 2482.516"
-		Rot="0.000 -0.225 0.000 0.974" />
+		Pos="2558.200 248.734 2397.174"
+		Rot="0.000 0.212 0.000 0.977" />
 
 	<Object
 		Name="sack_wall13577"

--- a/patch/maps/r1m4/triggers.xml
+++ b/patch/maps/r1m4/triggers.xml
@@ -7,6 +7,7 @@
 			SetVar("Boloto",0)
 			SetVar("SubMarPh",0)
 			SetVar("MainCarDead", 0)
+			SetVar("NPTTeamsDead", 0)
 		    trigger:Deactivate()
 		</script>
 	</trigger>
@@ -119,21 +120,23 @@
 			local lcar = getObj("LeaderCar_vehicle_0")
 			if lcar then
 				lcar:AttachTrailer("MolokovozTrailer")
-				local nametr = lcar:GetName().."_Trailer"
-				local trailer = getObj(nametr)
+				lcar:setImmortalMode(1)
+				local trailer = lcar:GetTrailer()
 				if trailer then
 					trailer:SetSkin(lcar:GetSkin())
-				   local tr = getObj("trLeaderCarDie")
-				   if tr then
-				      tr:AddEvent("GE_OBJECT_DIE",nametr)
-	   			   end
+					trailer:setImmortalMode(1)
+					local nametr = trailer:GetName()
+				   	local tr = getObj("trLeaderCarDie")
+				   	if tr then tr:AddEvent("GE_VEHICLE_WITHOUT_HEALTH",nametr) end
 	   			end
 	   		end
 
-			TActivate("trLeaderCaravanDie")
+			TActivate("trMainCarDie")
+			TActivate("trLeaderGuardsDie")
 			TActivate("trLeaderCarDie")
 			TActivate("trNearCaravanLeader")
 			TActivate("trExtrLeader")
+
 			trigger:Deactivate()
 		</script>
 	</trigger>
@@ -185,45 +188,82 @@
 	</trigger>
 
 <!-- Охрана лидера померла -->
-	<trigger Name="trLeaderCaravanDie" active="0">
-		<event eventid="GE_OBJECT_DIE" ObjName="LeaderGuardTeam" />
-		<event eventid="GE_OBJECT_DIE" ObjName="LeaderCar_vehicle_0" />
+	<trigger Name="trMainCarDie" active="0">
+		<event eventid="GE_VEHICLE_WITHOUT_HEALTH" ObjName="LeaderCar_vehicle_0" />
 		<script>
-			if getObj("LeaderCar_vehicle_0"):IsAlive() or GetVar("MainCarDead").AsInt==1 then
-				CompleteQuest("FreeExtremistLeader_Quest3_1")
-			else
+			local count = GetVar("NPTTeamsDead").AsInt
+
+			if not(IsQuestTaken("FreeExtremistLeader_Quest3_2")) then
+				TakeQuest("FreeExtremistLeader_Quest3_2")
 				CompleteQuest("FreeExtremistLeader_Quest3_2")
-				SetVar("MainCarDead", 1)
+			else
+				CompleteQuestIfTaken("FreeExtremistLeader_Quest3_2")
 			end
-			trigger:IncCount()
-			local count = trigger:GetCount()
-		    if 2>count then
-		    	return
-		    end
---		    println("trLeaderCaravan DIEEEEEEEEEEEEEEEEEEEE")
+
+			local lcar = getObj("LeaderCar_vehicle_0")
+			if lcar then
+				lcar:SetMaxSpeed(0)
+				lcar:SetMaxTorque(0)
+				lcar:SetThrottle(0)
+				lcar:SetCustomLinearVelocity(0)
+				lcar:TakeOffAllGuns()
+			end
+
+			SetVar("NPTTeamsDead", count+1)
+
+			TActivate("trLeaderCaravanDie")
+
+			trigger:Deactivate()
+		</script>
+	</trigger>
+
+	<trigger Name="trLeaderGuardsDie" active="0">
+		<event eventid="GE_OBJECT_DIE" ObjName="LeaderGuardTeam" />
+		<script>
+			local count = GetVar("NPTTeamsDead").AsInt
+
+			CompleteQuest("FreeExtremistLeader_Quest3_1")
+			if not(IsQuestTaken("FreeExtremistLeader_Quest3_2")) then
+				TakeQuest("FreeExtremistLeader_Quest3_2")
+			end
+
+			SetVar("NPTTeamsDead", count+1)
+
+			TActivate("trLeaderCaravanDie")
+
+			trigger:Deactivate()
+		</script>
+	</trigger>
+
+	<trigger Name="trLeaderCaravanDie" active="0">
+		<event	timeout="0.01"		eventid="GE_TIME_PERIOD" />
+		<script>
+			local count = GetVar("NPTTeamsDead").AsInt
+			if count == 2 then
+				TDeactivate("trLeaderCarDie")
 			
-			SaveAllToleranceStatus(RS_NEUTRAL)
+				SaveAllToleranceStatus(RS_NEUTRAL)
 
-			local Plf = GetPlayerVehicle()
-			local PlfID = GetPlayerVehicleId()
-			local PlfCoor = Plf:GetPosition()
-			PlfCoor.y = PlfCoor.y + 5
-			PlfCoor.z = PlfCoor.z - 20
+				local Plf = GetPlayerVehicle()
+				local PlfID = GetPlayerVehicleId()
+				local PlfCoor = Plf:GetPosition()
+				PlfCoor.y = PlfCoor.y + 5
+				PlfCoor.z = PlfCoor.z - 20
 
-			Plf:SetCustomControlEnabled( true )
-			Plf:SetCustomLinearVelocity( 0 )
-			Plf:SetThrottle( 0 )
-			Plf:SetCustomControlEnabled( false )
+				Plf:SetCustomControlEnabled( true )
+				Plf:SetCustomLinearVelocity( 0 )
+				Plf:SetThrottle( 0 )
+				Plf:SetCustomControlEnabled( false )
 
-			FlyAround(2, 0, 35, 25, PlfCoor, PlfID, 1, 1 )
-			StartCinematic()
+				FlyAround(2, 0, 35, 27.5, PlfCoor, PlfID, 1, 1 )
+				StartCinematic()
 
-			AddCinematicMessage( 10, 1 )
-			AddCinematicMessage( 11, 1 )
-			AddCinematicMessage( 12, 1 )
+				AddCinematicMessage( 10, 1 )
+				AddCinematicMessage( 11, 1 )
+				AddCinematicMessage( 12, 1 )
 
-			TActivate("trLeaderCaravanDie_End")
-			TDeactivate("trLeaderCarDie")
+				TActivate("trLeaderCaravanDie_End")
+			end
 
 			trigger:Deactivate()
 		</script>
@@ -252,6 +292,16 @@
 		<script>
 --		    println("trLeaderCar DIEEEEEEEEEEEEEEEEEEEE")
 			
+			TDeactivate("trMainCarDie")
+			TDeactivate("trLeaderGuardsDie")
+
+			local lcar = getObj("LeaderCar_vehicle_0")
+			if lcar then
+				lcar:setImmortalMode(0)
+				lcar:GetTrailer():setImmortalMode(0)
+				lcar:AddModifier("hp", "= 0")
+			end
+
 			SaveAllToleranceStatus(RS_NEUTRAL)
 
 			local Plf = GetPlayerVehicle()
@@ -265,7 +315,7 @@
 			Plf:SetThrottle( 0 )
 			Plf:SetCustomControlEnabled( false )
 
-			FlyAround(2, 0, 35, 16, PlfCoor, PlfID, 1, 1 )
+			FlyAround(2, 0, 35, 17, PlfCoor, PlfID, 1, 1 )
 			StartCinematic()
 
 			AddCinematicMessage( 13, 1 )
@@ -288,6 +338,8 @@
 	<event eventid="GE_SKIP_CINEMATIC" ObjName="Player1" />
 		<script>
 			RestoreAllToleranceStatus()
+
+			SetCameraBehindPlayerVehicle()
 
 			for i = 0,2 do
 				if GetEntityByName("LeaderGuardTeam_vehicle_"..i) then GetEntityByName("LeaderGuardTeam_vehicle_"..i):Remove() end


### PR DESCRIPTION
## Исправил логику таким образом, чтобы трейлер не взрывался вместе с головной машиной.
### Прилагаю схему того, как теперь всё работает.
# Помимо этого исправил кинематографический коэффициент весны и чуть поднял первую камеру по `y`, чтобы она не проваливалась под землю

А, да, ещё бродяжьи доты чуть в сторону отнёс, чтобы молоковоз тсп не врезался в них


![image](https://github.com/DeusExMachinaTeam/EM-CommunityPatch/assets/68562524/d688cc7f-c508-4517-869d-a4cf3dfac413)

Сейв для тестов: 
[кал говна.zip](https://github.com/DeusExMachinaTeam/EM-CommunityPatch/files/11543395/default.zip)
