### PR TITLE
Chests & Alone Druid house fix

### DIFF
--- a/patch/maps/r1m3/dynamicscene.xml
+++ b/patch/maps/r1m3/dynamicscene.xml
@@ -3258,7 +3258,7 @@
 		Name="SecretPlace6_loc"
 		Belong="1001"
 		Prototype="genericLocation"
-		Pos="2430.564 260.000 4065.417"
+		Pos="2450.564 260.000 4090.417"
 		Radius="10.000" />
 
 	<Object

--- a/patch/maps/r2m1/dynamicscene.xml
+++ b/patch/maps/r2m1/dynamicscene.xml
@@ -4403,7 +4403,7 @@
 		Name="SecretPlace16_loc"
 		Belong="1001"
 		Prototype="genericLocation"
-		Pos="1299.769 233.000 5000.968"
+		Pos="1269.769 233.000 5020.968"
 		Radius="10.000" />
 
 	<Object

--- a/patch/maps/r3m2/object_names.xml
+++ b/patch/maps/r3m2/object_names.xml
@@ -65,6 +65,10 @@
 		FullName="Мастерская друида" />
 
 	<Object
+		Name="AloneDruid_Bar"
+		FullName="Дом друида" />
+
+	<Object
 		Name="heavy_dot3_vulcan1"
 		FullName="Дот" />
 


### PR DESCRIPTION
Исправление застрявших под асфальтом тайников на локациях Фатерлянд и Либриум. Также добавляет отсутствующее название для вкладки "дом" у хижины друида в Игнотте.