### PR TITLE
r1m4 storage cutscene fix

### DIFF
--- a/patch/gamedata/quests.xml
+++ b/patch/gamedata/quests.xml
@@ -1394,7 +1394,7 @@
 		CheckAll="1"
 		ConditionToGive="all complete"
 		OnComplete="AddPlayerMoney(2000)"
-		OnFail='SetTolerance(1100, 1010, RS_NEUTRAL); TDeactivate("trNearCaravanLeader"); TDeactivate("trLeaderCaravanDie"); TDeactivate("trLeaderCarDie")'
+		OnFail='SetTolerance(1100, 1010, RS_NEUTRAL); TDeactivate("trNearCaravanLeader"); TDeactivate("trLeaderGuardsDie"); TDeactivate("trMainCarDie")'
 		Levels="r1m4">
 		<quest
 			Name="TRS_Quest2"
@@ -1448,7 +1448,7 @@
 			CheckAll="0"
 			ConditionToGive="all taken"
 			PrecedingQuests="FreeExtremistLeader_Quest1"
-			OnComplete='TActivate("trFreeExtremistLeader_Take")'
+			OnComplete='TActivate("trNearCaravanLeader")'
 			Levels="r1m4" />
 
 		<quest

--- a/patch/maps/r1m4/camera_paths.xml
+++ b/patch/maps/r1m4/camera_paths.xml
@@ -1,25 +1,12 @@
 <?xml version="1.0" encoding="windows-1251" standalone="yes"?>
 <Paths>
-	<Path Name = "MorassNoPath">
-		<Point coord="0 10 -50" rotation="0.0 0.0 0.0 0.0" zoom="1.0" />
-	</Path>
-
-	<Path Name = "circle">                         
-		<Point coord="36.712 260.283 64.978" rotation="-0.095 -0.742 0.108 0.654" zoom="1.0" />
-		<Point coord="59.839 257.949 33.428" rotation="-0.069 0.008 -0.001 0.998" zoom="2.0" />
-		<Point coord="78.272 264.514 55.376" rotation="-0.243 0.547 -0.170 0.783" zoom="0.7" />
-		<Point coord="66.793 253.438 85.261" rotation="-0.011 0.984 -0.065 0.168" zoom="1.0" />
-	</Path>
-
-	<Path Name = "relative">                         
-		<Point coord="0 10 -50" rotation="0.0 0.0 0.0 0.0" zoom="1.0" />
-	</Path>
-
+	<!-- Болото закрыто. -->
 	<Path Name = "BolotoOF_cam01">                         
 		<Point  coord="1266.468 213.171 1519.520" rotation="0.008 -0.468 -0.004 0.884"/>
 		<Point  coord="1250.052 213.171 1554.609" rotation="-0.000 -0.632 0.000 0.775"/>
 	</Path>
 
+	<!-- Болото открыто. -->
 	<Path Name = "Boloto_cam01">                         
 		<Point coord="-4.510 1.500 20.571" rotation="0.090 -0.603 -0.068 0.790"/>
 	</Path>
@@ -30,10 +17,9 @@
 
 	<Path Name = "Boloto_cam03">                         
 		<Point  coord="878.287 241.002 1723.050" rotation="0.038 0.891 -0.075 -0.446"/>
-<!-- 		<Point  coord="878.287 240.002 1723.050" rotation="0.038 0.891 -0.075 -0.446"/>		 -->
 	</Path>
 
-
+	<!--переезд болота от самолета в деревню. -->
 	<Path Name = "Boloto_cam03Port">                         
 		<Point  coord="933.167 230.258 1670.495" rotation="0.049 0.579 0.035 0.813"/>
 		<Point  coord="946.653 240.801 1668.705" rotation="-0.007 0.626 -0.005 0.780"/>
@@ -49,11 +35,13 @@
 		<Point  coord="1473.342 225.361 1539.949" rotation="-0.052 0.345 -0.019 0.937"/>
 	</Path>
 
+	<!--переезд болота от порта в деревню.-->
 	<Path Name = "PortOut_cam01">                         
 		<Point  coord="787.966 250.249 1703.446" rotation="-0.192 -0.703 0.207 0.652"/>
 		<Point  coord="771.337 262.521 1703.464" rotation="-0.047 -0.753 0.055 0.655"/>
 	</Path>
 
+	<!-- Босс кран -->
 	<Path Name = "Boss02_cam01">                         
 		<Point  coord="833.949 270.194 1368.301" rotation="0.029 0.423 0.013 0.906"/>
 		<Point  coord="833.575 275.535 1360.280" rotation="-0.046 0.106 -0.005 0.993"/>
@@ -69,21 +57,28 @@
 		<Point  coord="-4.000 1.500 -20.000"/>
 	</Path>
 
+	<!-- Ролик подьезда к конвою лидера экстримистов -->
+	<Path Name = "Caravan_cam00">                         
+		<Point  coord="10.000 6.500 -30.000"/>
+		<Point  coord="10.000 7.500 -20.000"/>
+	</Path>
+
 	<Path Name = "Caravan_cam01">                         
-		<Point  coord="-2.000 6.500 -30.000"/>
-		<Point  coord="2.000 7.500 -40.000"/>
+		<Point  coord="-10.000 4.500 -30.000"/>
+		<Point  coord="-10.000 5.500 -20.000"/>
 	</Path>
 
 	<Path Name = "Caravan_cam02">                         
-		<Point  coord="-4.000 4.000 -20.000"/>
-		<Point  coord="4.000 6.500 -20.000"/>
+		<Point  coord="4.000 4.000 20.000"/>
+		<Point  coord="100.000 40.500 50.000"/>
 	</Path>
 
 	<Path Name = "Caravan_cam03">                         
-		<Point  coord="-4.000 3.000 10.000"/>
-		<Point  coord="4.000 6.500 20.000"/>
+		<Point  coord="-30.000 9.500 -30.000"/>
+		<Point  coord="-30.000 5.000 -20.000"/>
 	</Path>
 
+	<!--подводная лодка-->
 	<Path Name = "lodka1">                         
 		<Point  coord="779.983 271.674 1037.732" rotation="-0.000 1.000 -0.007 0.017"/>
 		<Point  coord="775.084 249.252 877.352" rotation="-0.000 1.000 -0.000 0.015"/>
@@ -99,6 +94,7 @@
 		<Point  coord="680.886 220.828 766.145" rotation="-0.002 0.905 0.004 -0.426"/>
 	</Path>
 
+	<!-- Путь подводной лодки -->
 	<Path Name = "lodka4">                         
 		<Point  coord="712.726 160.000 67.000" rotation="0.000 -0.008 -0.000 -1.000"/>
 		<Point  coord="710.435 216.935 630.735" rotation="0.000 -0.008 -0.000 -1.000"/>

--- a/patch/maps/r1m4/cinematriggers.xml
+++ b/patch/maps/r1m4/cinematriggers.xml
@@ -431,36 +431,39 @@
 <!--			Ролик подьезда к конвою лидера экстримистов		-->
 
 	<trigger Name="RolikBegin_NearCaravanLeader" active="0">
-		<event timeout="0" eventid="GE_TIME_PERIOD" />
+		<event timeout="0.01" eventid="GE_TIME_PERIOD" />
 		<script>
-		    SaveAllToleranceStatus(RS_NEUTRAL)
-			GetPlayerVehicle():SetCustomLinearVelocity( 0 )
+			ShowHostileVehicles(false)
+
+			SaveAllToleranceStatus(RS_NEUTRAL)
 
 			TActivate("RolikEnd_NearCaravanLeader")
+			TActivate("trCaravan_cam01")
 			TActivate("trCaravan_cam02")
 			TActivate("trCaravan_cam03")
 			TActivate("trCaravan_Fade")
+
 			PlayCustomMusic("Passage01unloop")
+
 			RuleConsole("cinematic_spring_coeff 6.0")
 
-			local Band = GetEntityByName("LeaderGuardTeam_vehicle_0")
+			local leader_car = CreateVehicleEx("Molokovoz01", "NPT_vehicle_4", CVector(0, 1000, 0), 1010, Quaternion(-0.016, 0.946, -0.025, 0.324))
+
+			CreateVehicleEx("Bug01", "NPT_vehicle_3", CVector(0, 2000, 0), 1010, Quaternion(-0.011, 0.990, -0.027, 0.135))
+
+			local Band = GetEntityByName("NPT_vehicle_3")
 			local BandID = Band:GetId()
 			local vehPID = GetPlayerVehicleId()
-			local Lider = GetEntityByName("LeaderCar_vehicle_0")
+			local Lider = GetEntityByName("NPT_vehicle_4")
 			local LiderID = Lider:GetId()
 
-			FlyLinked( "Caravan_cam01", BandID , 14, 1, 0, vehPID, nil, true, nil, nil )
-			FlyLinked("Caravan_cam02", vehPID, 17, 0, 0, BandID, nil, true, nil, true )
-			FlyLinked("Caravan_cam03", LiderID, 18.5, 0, 1, LiderID, nil, true, nil, true )
+			FlyLinked( "Caravan_cam00", BandID , 7, 1, 0, vehPID, nil, true, nil, nil )
+			FlyLinked( "Caravan_cam01", vehPID , 6, 0, 0, LiderID, nil, true, nil, nil )
+			FlyLinked("Caravan_cam02", LiderID, 17, 0, 0, LiderID, nil, true, nil, nil )
+			FlyLinked("Caravan_cam03", vehPID, 18, 0, 1, LiderID, nil, true, nil, nil )
 			StartCinematic()
 
 			AddCinematicMessage( 4, 1 )
-			AddCinematicMessage( 5, 1 )
-
-			local PlVehicle = GetPlayerVehicle()
-			if PlVehicle then
-				PlVehicle:SetThrottle(0)
-			end
 
 			trigger:Deactivate()
 		</script>
@@ -469,13 +472,103 @@
 	<trigger Name="trCaravan_Fade" active="0">
 		<event eventid="GE_CINEMATIC_ENTER_FADE_IN" ObjName="Player1" />
 		<script>
+			local npt_car1 = CreateVehicleEx("Revolutioner2", "NPT_vehicle_1", CVector(2335.757, 250.426, 2975.369), 1010, Quaternion(0.000, 0.964, 0.000, 0.265))
+			local npt_car2 = CreateVehicleEx("Bug01", "NPT_vehicle_2", CVector(2325.117, 250.077, 3000.081), 1010, Quaternion(0.025, 0.985, 0.018, 0.170))
+			local npt_car3 = getObj("NPT_vehicle_3")
+			if npt_car3 then
+				npt_car3:SetGamePositionOnGround(CVector(2316.018, 251.340, 3028.088))
+				npt_car3:SetRotation(Quaternion(-0.011, 0.990, -0.027, 0.135))
+			end
+
+			-- Вынесено в отдельный триггер, потому что кончалыги из Таргем Геймс не умеют делать игры
+			TActivate("trPlaceLeaderCar")
+
+			local lcar = getObj("NPT_vehicle_4")
+			if lcar then lcar:AttachTrailer("MolokovozTrailer") end
+
+			for car = 1,4 do
+				local npt_car = getObj("NPT_vehicle_"..car)
+				if npt_car then
+					npt_car:SetCruisingSpeed(12)
+					npt_car:SetExternalPathByName("LeaderCar_path01")
+					npt_car:SetRandomSkin()
+				end
+			end
+
+			-- покраска трейлера после общего проставления скинов
+			if lcar then PaintTrailer(lcar) end
+
 			local vehPlayer = GetPlayerVehicle()
 			if vehPlayer then
 				vehPlayer:SetCustomControlEnabled( true )
 				vehPlayer:SetCustomLinearVelocity( 0 )
 				vehPlayer:SetThrottle( 0 )
 				vehPlayer:SetCustomControlEnabled( false )
+				vehPlayer:SetGamePositionOnGround(CVector(2508.524, 250.664, 2645.997))
+				vehPlayer:SetRotation(Quaternion(0.005, -0.135, 0.009, 0.991))
+				vehPlayer:LimitMaxSpeed(5)
+				vehPlayer:SetCustomLinearVelocity( 20 )
+				vehPlayer:SetExternalPathByName("player_path07")
 			end
+
+			TActivate("trCaravanLeaderReach")
+			TActivate("trCaravan1stVehReach")
+			TActivate("trCaravan2ndVehReach")
+			
+			trigger:Deactivate()
+		</script>
+	</trigger>
+
+	<!-- Вынесено в отдельный триггер, потому что кончалыги из Таргем Геймс не умеют делать игры -->
+	<trigger Name="trPlaceLeaderCar" active="0">
+		<event	timeout="0.01"		eventid="GE_TIME_PERIOD" />
+		<script>
+			local lcar = getObj("NPT_vehicle_4")
+			if lcar then
+				lcar:SetGamePositionOnGround(CVector(2350.553, 250.322, 2952.802))
+				lcar:SetRotation(Quaternion(-0.016, 0.946, -0.025, 0.324))
+			end
+			
+			trigger:Deactivate()
+		</script>
+	</trigger>
+
+	<trigger Name="trCaravanLeaderReach" active="0">
+		<event eventid="GE_TARGET_REACHED" ObjName="NPT_vehicle_4"/>
+		<script>
+			local npt_car1 = getObj("NPT_vehicle_4")
+			if npt_car1 then npt_car1:SetExternalPathByName("LeaderCar_path02") end
+
+			trigger:Deactivate()
+		</script>
+	</trigger>
+
+	<trigger Name="trCaravan1stVehReach" active="0">
+		<event eventid="GE_TARGET_REACHED" ObjName="NPT_vehicle_1"/>
+		<script>
+			local npt_car2 = getObj("NPT_vehicle_1")
+			if npt_car2 then npt_car2:SetExternalPathByName("LeaderCar_path03") end
+			
+			trigger:Deactivate()
+		</script>
+	</trigger>
+
+	<trigger Name="trCaravan2ndVehReach" active="0">
+		<event eventid="GE_TARGET_REACHED" ObjName="NPT_vehicle_2"/>
+		<script>
+			local npt_car3 = getObj("NPT_vehicle_2")
+			if npt_car3 then npt_car3:SetExternalPathByName("LeaderCar_path04") end
+			
+			trigger:Deactivate()
+		</script>
+	</trigger>
+
+	<trigger Name="trCaravan_cam01" active="0">
+		<event flypath="Caravan_cam01" eventid="GE_START_CINEMATIC_FLY" ObjName="Player1" />
+		<script>
+
+			AddCinematicMessage( 5, 1 )
+
 			trigger:Deactivate()
 		</script>
 	</trigger>
@@ -486,14 +579,8 @@
 
 			PlayCustomMusic("IntenseDialogue01")
 
-			local vehPlayer = GetPlayerVehicle()
-			if vehPlayer then
-				vehPlayer:SetThrottle(0)
-				vehPlayer:SetCustomLinearVelocity(0)
-			end
-
 			AddCinematicMessage( 6, 1 )
-			AddCinematicMessage( 7, 1 )
+			AddCinematicMessage( 7, 1 )	
 
 			trigger:Deactivate()
 		</script>
@@ -514,18 +601,98 @@
 		<event eventid="GE_SKIP_CINEMATIC" ObjName="Player1" />
 		<script>
 
-		RuleConsole("cinematic_spring_coeff 0.7")
-	    RestoreAllToleranceStatus()
-		SetTolerance(1100, 1010, RS_ENEMY)
+			RuleConsole("cinematic_spring_coeff 0.7")
 
-		StopPlayingCustomMusic()
-		TDeactivate("RolikEnd_NearCaravanLeader")
-		TDeactivate("trCaravan_cam02")           
-		TDeactivate("trCaravan_cam03")           
-		SetCameraBehindPlayerVehicle()
-		CompleteQuest("FreeExtremistLeader_Quest3")
-		TakeQuest("FreeExtremistLeader_Quest3_1")
-		trigger:Deactivate()
+			RestoreAllToleranceStatus()
+
+			ShowHostileVehicles(true)
+
+			SetTolerance(1100, 1010, RS_ENEMY)
+
+			StopPlayingCustomMusic()
+
+			local skins = {1,2,3,4}
+			for car = 1,4 do
+				local npt_car = getObj("NPT_vehicle_"..car)
+				if npt_car then
+					skins[car] = npt_car:GetSkin()
+					npt_car:Remove()
+				end
+			end
+
+			TeamCreate("LeaderGuardTeam",1010,CVector(getPos("LeaderCaravanStart_loc")),{"Revolutioner2","Bug01","Bug01"})
+
+			local guard1 = getObj("LeaderGuardTeam"):GetVehicle(0)
+			if guard1 then
+				guard1:SetGamePositionOnGround(CVector(2450.231, 250.268, 2751.583))
+				guard1:SetRotation(Quaternion(-0.001, 0.998, -0.005, -0.067))
+				guard1:SetSkin(skins[1])
+			end
+
+			local guard2 = getObj("LeaderGuardTeam"):GetVehicle(1)
+			if guard2 then
+				guard2:SetGamePositionOnGround(CVector(2496.796, 250.706, 2769.292))
+				guard2:SetRotation(Quaternion(-0.020, 0.890, -0.011, 0.456))
+				guard2:SetSkin(skins[2])
+			end
+
+			local guard3 = getObj("LeaderGuardTeam"):GetVehicle(2)
+			if guard3 then
+				guard3:SetGamePositionOnGround(CVector(2458.987, 251.953, 2800.566))
+				guard3:SetRotation(Quaternion(0.003, 0.983, 0.001, 0.182))
+				guard3:SetSkin(skins[3])
+			end
+
+			TeamCreate("LeaderCar",1010,CVector(2474.402, 250.483, 2751.904),{"Molokovoz01"}, nil, nil, Quaternion(0.033, 0.988, -0.001, 0.153))
+
+			local lcar = getObj("LeaderCar_vehicle_0")
+			if lcar then
+				lcar:SetSkin(skins[4])
+				lcar:AttachTrailer("MolokovozTrailer")
+				local trailer = lcar:GetTrailer()
+				lcar:setImmortalMode(1)
+				trailer:setImmortalMode(1)
+				local nametr = trailer:GetName()
+				PaintTrailer(lcar)
+
+				local tr = getObj("trLeaderCarDie")
+				if tr then
+					tr:AddEvent("GE_VEHICLE_WITHOUT_HEALTH", nametr)
+				end
+			end
+
+			local vehPlayer = GetPlayerVehicle()
+			if vehPlayer then
+			vehPlayer:SetCustomControlEnabled( true )
+			vehPlayer:SetCustomLinearVelocity( 0 )
+			vehPlayer:SetThrottle( 0 )
+			vehPlayer:SetCustomControlEnabled( false )
+			vehPlayer:SetGamePositionOnGround(CVector(2490.111, 251.402, 2712.311))
+			vehPlayer:SetRotation(Quaternion(0.027, -0.156, 0.006, 0.987))
+			vehPlayer:UnlimitMaxSpeed()
+			vehPlayer:PlaceToEndOfPath("player_path07")
+			vehPlayer:setGodMode(0)
+			end
+
+			SetCameraBehindPlayerVehicle()
+
+			TDeactivate("trCaravan_cam01")
+			TDeactivate("trCaravan_cam02")           
+			TDeactivate("trCaravan_cam03")   
+			TDeactivate("trCaravan_Fade")
+			TDeactivate("trCaravanLeaderReach")
+			TDeactivate("trCaravan1stVehReach")
+			TDeactivate("trCaravan2ndVehReach")
+
+			TActivate("trMainCarDie")
+			TActivate("trLeaderGuardsDie")
+			TActivate("trLeaderCarDie")
+			TActivate("trPlGOdMode2sec")
+
+			CompleteQuest("FreeExtremistLeader_Quest3")
+			TakeQuest("FreeExtremistLeader_Quest3_1")
+
+			trigger:Deactivate()
 		</script>
 	</trigger>
 

--- a/patch/maps/r1m4/dynamicscene.xml
+++ b/patch/maps/r1m4/dynamicscene.xml
@@ -1362,20 +1362,11 @@
 
 	<Object
 		Flags="21"
-		Name="LeaderCaravanSpawn_loc"
-		Belong="1100"
-		Prototype="genericLocation"
-		Pos="2348.362 248.474 2963.589"
-		Radius="258.349"
-		LookingTimeOut="12.000" />
-
-	<Object
-		Flags="21"
 		Name="LeaderCaravanStart_loc"
 		Belong="1100"
 		Prototype="genericLocation"
-		Pos="2347.385 248.354 2954.580"
-		Radius="680.253"
+		Pos="2387.726 248.912 2911.708"
+		Radius="300.253"
 		LookingTimeOut="60.000" />
 
 	<Object

--- a/patch/maps/r1m4/external_paths.xml
+++ b/patch/maps/r1m4/external_paths.xml
@@ -1699,8 +1699,62 @@
 	</Path>
 
 	<Path
+		Name="player_path07">
+		<Point
+			coord="2507.771 2651.596" />
+
+		<Point
+			coord="2499.613 2683.082" />
+
+		<Point
+			coord="2487.873 2719.343" />
+	</Path>
+
+	<Path
 		Name="subzaezd1">
 		<Point
 			coord="714.643 699.526" />
+	</Path>
+
+	<Path
+		Name="LeaderCar_path01">
+		<Point
+			coord="2361.164 2940.181" />
+
+		<Point
+			coord="2379.970 2923.036" />
+
+		<Point
+			coord="2406.879 2899.690" />
+
+		<Point
+			coord="2422.408 2881.977" />
+
+		<Point
+			coord="2433.690 2861.261" />
+
+		<Point
+			coord="2447.021 2831.019" />
+
+		<Point
+			coord="2461.036 2795.315" />
+	</Path>
+
+	<Path
+		Name="LeaderCar_path02">
+		<Point
+			coord="2474.752 2750.731" />
+	</Path>
+
+	<Path
+		Name="LeaderCar_path03">
+		<Point
+			coord="2448.491 2747.151" />
+	</Path>
+
+	<Path
+		Name="LeaderCar_path04">
+		<Point
+			coord="2499.592 2767.686" />
 	</Path>
 </Paths>

--- a/patch/maps/r1m4/triggers.xml
+++ b/patch/maps/r1m4/triggers.xml
@@ -110,77 +110,13 @@
 
 		</script>
 	</trigger>
-<!-- Создаем отряд охраны лидера -->
-	<trigger	Name="trFreeExtremistLeader_Take" active="0">
-		<event	timeout="1"	eventid="GE_TIME_PERIOD" />
-		<script>
---			println("Leader Caravan Guards Created")
-			TeamCreate("LeaderGuardTeam",1010,CVector(getPos("LeaderCaravanSpawn_loc")),{"Revolutioner2","Bug01","Bug01"}, CVector(2359.986, 254.000, 2939.419))
-			TeamCreate("LeaderCar",1010,CVector(getPos("LeaderCaravanSpawn_loc")),{"Molokovoz01"}, CVector(2359.986, 254.000, 2939.419))
-			local lcar = getObj("LeaderCar_vehicle_0")
-			if lcar then
-				lcar:AttachTrailer("MolokovozTrailer")
-				lcar:setImmortalMode(1)
-				local trailer = lcar:GetTrailer()
-				if trailer then
-					trailer:SetSkin(lcar:GetSkin())
-					trailer:setImmortalMode(1)
-					local nametr = trailer:GetName()
-				   	local tr = getObj("trLeaderCarDie")
-				   	if tr then tr:AddEvent("GE_VEHICLE_WITHOUT_HEALTH",nametr) end
-	   			end
-	   		end
 
-			TActivate("trMainCarDie")
-			TActivate("trLeaderGuardsDie")
-			TActivate("trLeaderCarDie")
-			TActivate("trNearCaravanLeader")
-			TActivate("trExtrLeader")
-
-			trigger:Deactivate()
-		</script>
-	</trigger>
-
-<!-- едем освобождать лидера, они выдвигаются в сторону Ольма-->
-	<trigger	Name="trExtrLeader"	active="0">
-		<event	eventid="GE_OBJECT_ENTERS_LOCATION"	ObjName="LeaderCaravanStart_loc" />
-		<script>
-			local GuardTeam=GetEntityByName("LeaderGuardTeam")
-			if GuardTeam then
-				GuardTeam:SetDestination(CVector(2684.543, 249.000, 2287.926))
-			end
-
-			local LeaderTeam=GetEntityByName("LeaderCar")
-			if LeaderTeam then
-				LeaderTeam:SetDestination(CVector(2686.543, 249.000, 2289.926))
-			end
-
-			TActivate("trMoveCaravanLoc")
-			trigger:Deactivate()
-		</script>
-	</trigger>
-
-	<trigger	Name="trMoveCaravanLoc" active="0">
-		<event	timeout="0.5"	eventid="GE_TIME_PERIOD" />
-		<script>
---			println("trMoveCaravanLoc")
-			local pos=CVector(getPos("LeaderCar_vehicle_0"))
---			println("pos = "..pos)
-			local myloc=getObj("LeaderCaravanSpawn_loc")
---			println("222222222")
-			if myloc and pos then
---			println("33333333")
---			   myloc:SetPosition(CVector(pos))
-			   myloc:SetPosition(pos)
-			end
-		</script>
-	</trigger>
 <!-- подъехали близко к каравану-->
 	<trigger	Name="trNearCaravanLeader"	active="0">
-		<event	eventid="GE_OBJECT_ENTERS_LOCATION"	ObjName="LeaderCaravanSpawn_loc" />
+		<event	eventid="GE_OBJECT_ENTERS_LOCATION"	ObjName="LeaderCaravanStart_loc" />
 		<script>
---			SetTolerance(1100, 1010, RS_ENEMY)
 			SetTolerance(1100, 1010, RS_NEUTRAL)
+
 			TActivate("RolikBegin_NearCaravanLeader")
 
 			trigger:Deactivate()
@@ -358,8 +294,8 @@
 		<event	timeout="0.01"	eventid="GE_TIME_PERIOD" />
 		<script>
 			TDeactivate("trNearCaravanLeader")
-			TDeactivate("trLeaderCaravanDie")
-			TDeactivate("trLeaderCarDie")
+			TDeactivate("trLeaderGuardsDie")
+			TDeactivate("trMainCarDie")
 			
 			TeamCreate("ExtrGuardTeam",1065,CVector(getPos("StorageVil_deploy")),{"Revolutioner1","Revolutioner2","Bug01","Bug01","Revolutioner2"})			
 			SetTolerance(1100, 1065, RS_ENEMY)

--- a/patch/scripts/compatch.lua
+++ b/patch/scripts/compatch.lua
@@ -1,8 +1,28 @@
-CP_VERSION = "1.12"
+CP_VERSION = "1.14"
 
 -- by zatinu322:
 -- showing first narrator's text
 -- moved here, becouse this text has different speed in patch and remaster
 function ShowFirstNarratorText()
     AddCinematicMessage( 77771, 0.1)
+end
+
+-- paint trailer to main vehicle's skin
+function PaintTrailer( vehicleName )
+    local veh = getObj( vehicleName )
+    if not veh then
+        println("Error: attempt to index a nil value: "..vehicleName)
+        LOG("Error: attempt to index a nil value: "..vehicleName)
+        return
+    end
+
+	local trailer = veh:GetTrailer()
+    if not trailer then
+        println("Error: prototype "..vehicleName.." has no trailer.")
+        LOG("Error: prototype "..vehicleName.." has no trailer.")
+        return
+    end
+
+	local skinnum = veh:GetSkin()
+	trailer:SetSkin(skinnum)
 end

--- a/patch/scripts/debug.lua
+++ b/patch/scripts/debug.lua
@@ -1,0 +1,394 @@
+-- Debug shit
+-- $Id: debug.lua,v 1.40 2005/07/06 12:55:55 anton Exp $
+
+-------------------------------------------------
+-- some debug shit, remove it before release
+-------------------------------------------------
+
+function testLoadSave()
+	RuleConsole "save test1"
+	RuleConsole "load test1"
+	RuleConsole "save test2"
+end
+
+-- Just for bugfixing
+function SetPositionNull()
+	GetPlayerVehicle():SetPosition(nil)
+end
+
+-------------------------------
+-- some function for camera log
+function p()
+    local pos, rot, lookAt = GetCameraPos()
+    LOG(' <Point  coord="' .. strsub( tostring(pos), 2, strlen( tostring(pos) ) - 1 ) .. '" rotation="'.. strsub( tostring(rot), 2, strlen( tostring(rot) ) - 1 ) .. '"/>')
+end
+
+
+function c()
+    logCameraPos()
+end
+
+
+------------------------------
+--Player pos to log
+function plp()
+LOG("SetPosition( CVector"..tostring(GetPlayerVehicle():GetPosition())..")")
+LOG(' SetRotation(Quaternion'..tostring(GetPlayerVehicle():GetRotation(Quaternion()))..')')
+end
+
+
+-- writes current camera position and angles to log
+function logPoint()
+	local pos, rot, lookAt = GetCameraPos()
+	local sPos = tostring(pos)
+	sPos = strsub( sPos, 2, strlen(sPos) - 1 )
+	local sRot = tostring(rot)
+	sRot = strsub( sRot, 2, strlen(sRot) - 1 )
+	LOG( "		<Point")
+	LOG( '			coord="'.. sPos ..'"' )
+	LOG( '			rotation="'.. sRot .. '"/>' )
+end
+
+-- writes current camera position and angles to log
+function logPointS()
+	local pos, rot, lookAt = GetCameraPos()
+	local sPos = tostring(pos)
+	sPos = strsub( sPos, 2, strlen(sPos) - 1 )
+	local sRot = tostring(rot)
+	sRot = strsub( sRot, 2, strlen(sRot) - 1 )
+	writeln( "		<Point")
+	writeln( '			coord="'.. sPos ..'"' )
+	writeln( '			rotation="'.. sRot .. '"/>' )
+end
+
+-----------------------
+-- create army (cheat!)
+
+-- debug creation of objects in Player position
+function DebugCreate( PrototypeName, Belong )
+	local id = CreateNewObject{
+		prototypeName = PrototypeName,
+		objName = "debug_object"..tostring(random(9999)),
+		belong = Belong
+	}
+
+	local obj = GetEntityByID( id )
+
+	println( "Object created. id = "..tostring(id) )
+end
+
+
+function CreateVehicleEx( PrototypeName, Name, pos, belong )
+	local bel
+
+	if belong then
+		bel = belong
+	else
+		bel = 1100
+	end
+
+	local id = CreateNewObject {
+		prototypeName = PrototypeName,
+		objName = Name,
+		belong = bel
+	}
+
+	local vehicle = GetEntityByID( id )
+	
+	if not vehicle then
+		println( "Error: vehicle ".. PrototypeName .. " not created" )
+		return nil
+	end
+
+--	by Anton: это не нужно, т.к. вызываем SetGamePositionOnGround()
+--	local hover = 1.5 * vehicle:GetSize().y
+--	pos.y = g_ObjCont:GetHeight( pos.x, pos.z ) + hover
+
+
+	vehicle:SetGamePositionOnGround( pos )
+
+	return vehicle
+end
+
+
+
+
+-- Moves player's vehicle to position
+function MovePlayer( x, y, z )
+	GetPlayerVehicle():SetPosition( CVector( x, y, z ) )
+end
+
+
+-- Moves player's vehicle to camera position
+function MovePlayerToCamera()
+	local pos, rot, lookAt = GetCameraPos()
+	GetPlayerVehicle():SetPosition( pos )
+end
+
+
+function sss()
+	local p = CreateDummy{ modelName ="StoneBridge",objName = "Bridge", pos = CVector( 2000, 2000, 255 ) }
+end
+
+function move( x, z )
+	GetEntityByName("Team17"):SetDestination( CVector( x, 100, z ) )
+end	
+
+function die( x )
+	GetEntityByName(x):AddModifier( "hp", "- 1000000" )
+end	
+
+function caravan()
+	GetEntityByName("TheTown"):SpawnCaravanToLocation("TheEnd")
+--	GetEntityByName("TheTown"):SpawnCaravanToLocation("TheTown_defend")
+end
+
+
+function save()
+	g_ObjCont:SaveToFileFull( "aaa.xml" )
+end
+
+function load()
+	g_ObjCont:LoadFromFileFull( "aaa.xml" )	
+end
+
+function addgold( amount )
+	g_Player:AddMoney( amount )
+end
+
+function getgold()
+	return g_Player:GetMoney()
+end
+
+function ff()
+	Fly("testq", 0, 0, 30, 1, 1 )
+end
+
+function ffc()
+	Fly("circle", 0, 0, 10, 1, 1 )
+end
+
+function ffb()
+	Fly("big", 0, 0, 35, 1, 1 )
+end
+
+function ffr()
+	Fly("real", 0, 0, 15, 1, 1 )
+end
+
+function fff()
+	Fly("test", 0, 0, 4, 1, 1 )
+	AddCinematicMessage( 8000, 3 )
+	AddCinematicMessage( 1, 0.1 )
+end
+
+
+function testpath()
+	GetEntityByName("enemy"):SetPathByName("testVehicle")
+	GetEntityByName("enemy"):PlaceToEndOfPath()
+end
+
+function AddPlayerVehicle(modelname)
+-- добавляет игроку машину (если только у него ее нет)
+-- можно использовать, когда убъют или типа того.
+-- modelname - модель машины, которую надо. По умолчанию дается Урал
+    if not modelname then
+		modelname="Ural01"
+	end
+	if GetPlayerVehicle() then
+		local teamID = CreateNewObject{
+				prototypeName = "team",
+				objName = "TempTeam",
+				belong = "1100"
+			}
+	  	local team=GetEntityByID(teamID)
+		if team then team:AddChild(GetPlayerVehicle()) end
+		team:Remove()
+	end
+	local id = CreateNewObject{
+		prototypeName = modelname,
+--	 by Anton: name is set automatically in code --	objName = "PlayerVehicle"..tostring(random(9999)),
+		objName = "",
+		belong = 1100
+	}
+	local vehicle = GetEntityByID(id)
+	local pl=g_Player
+	if vehicle and pl then
+	    println("Car name: "..vehicle:GetName())
+		local hover = 1.5 * vehicle:GetSize().y
+    	local pos, yaw, pitch, roll, lookAt = GetCameraPos()
+		println(pos)
+		vehicle:SetPosition(pos)
+		pl:AddChild(vehicle)
+    end
+end
+
+function AddPlayerNewVehicle(modelname)
+-- добавляет игроку машину вместо текущей
+-- modelname - модель машины, которую надо. По умолчанию дается Урал
+
+    if not modelname then
+		modelname="Ural01"
+	end
+
+	local realpos
+	local Plf = GetPlayerVehicle()
+
+	if Plf then
+		realpos = Plf:GetPosition()
+		local teamID = CreateNewObject{
+				prototypeName = "team",
+				objName = "TempTeam",
+				belong = "1100"
+			}
+	  	local team=GetEntityByID(teamID)
+		if team then team:AddChild(GetPlayerVehicle()) end
+		team:Remove()
+	end
+
+	local id = CreateNewObject{
+		prototypeName = modelname,
+--	 by Anton: name is set automatically in code --			objName = "PlayerVehicle"..tostring(random(9999)),
+		objName = "",
+		belong = 1100
+	}
+
+	local vehicle = GetEntityByID(id)
+
+	local pl = g_Player
+
+	if vehicle and pl then
+		local hover = 1.5 * vehicle:GetSize().y
+		vehicle:SetPosition(realpos)
+		pl:AddChild(vehicle)
+    end
+end
+
+function fa()
+	FlyAround( 2, -0.5, 30, 5, CVector(60, 300, 60), GetPlayerVehicleId(), 1, 1 )
+end
+
+function fl()
+	GetPlayerVehicle():SetCustomControlEnabled(1)
+	GetPlayerVehicle():SetThrottle(1.0)
+	FlyLinked("relative", GetPlayerVehicleId(), 10, 1, 1)
+end
+
+function fl2()
+	GetPlayerVehicle():SetCustomControlEnabled(1)
+	GetPlayerVehicle():SetThrottle(1.0)
+	FlyLinked("relative", GetPlayerVehicleId(), 10, 1, 1)
+end
+
+
+function dsc()
+	GetPlayerVehicle():SetCustomControlEnabled(0)
+end
+
+function tec()
+	CreateEffect("ET_PS_BIGWHEELGRASSSPLASH", CVector(60, 250, 60), Quaternion(0, 0, 0, 1), 100, 0 )
+	CreateEffect("ET_PS_BIGWHEELGRASSSPLASH", CVector(70, 250, 70), Quaternion(0, 0, 0, 1), 0, 1 )
+end 
+
+function tgr()
+	local Workshop = GetEntityByName("TheTown_Workshop")
+	local Repository = Workshop:GetRepositoryByTypename("CabinsAndBaskets")
+	Repository:AddItems("belazCab01", 2)
+end
+
+function trailer( enable )
+	if enable ~= 0 then
+		GetPlayerVehicle():AttachTrailer("MolokovozTrailer")
+	else
+		GetPlayerVehicle():DetachTrailer()
+	end
+end
+
+
+function CreateDummy( prototype, modelName, mass, pos )
+	println(prototype)
+
+	local objId = CreateNewObject{ prototypeName = prototype, objName="ddd" }
+	local obj = GetEntityByID( objId )
+
+	obj:SetModelName( modelName )
+	obj:SetMass( mass )
+	obj:SetPosition( pos )
+end
+
+function PlayerDie()
+	GetPlayerVehicle():AddModifier("hp", "- 1000000" )
+end
+
+function  bbb()
+	getObj("boss"):StartMoving(CVector(200,300,200),CVector(1,0,0))
+end
+
+function  bbb1()
+	getObj("boss"):StartMoving(CVector(100,270,100),CVector(0,0,1))
+end
+
+function relCoord(name)
+	local veh=GetPlayerVehicle()
+	if name then 
+		local vehtmp = GetEntityByName(name)
+		if vehtmp then
+		   veh = vehtmp
+		else
+			println("Object with name "..name.." not exists")
+		end
+	end
+
+	local campos, camrot = GetCameraPos()
+	local vehpos = veh:GetPosition()
+	local pos=campos-vehpos
+	local rot=camrot
+    LOG(' <Point  ')
+    LOG('    coord="' .. strsub( tostring(pos), 2, strlen( tostring(pos) ) - 1 ) .. '"')
+    LOG('    rotation="'.. strsub( tostring(rot), 2, strlen( tostring(rot) ) - 1 ) .. '"/>')
+end
+
+
+function CreateEnemy(modelname)
+-- создает врага в позиции камеры
+    if not modelname then
+		modelname="Ural01"
+	end
+
+	local enemyname = "EnemyTeam"..tostring(random(9999))
+
+	local teamID = CreateNewObject{
+			prototypeName = "team",
+			objName = enemyname,
+			belong = "1002"
+		}
+  	local team=GetEntityByID(teamID)
+
+	local id = CreateNewObject{
+		prototypeName = modelname,
+		objName = "PlayerVehicle"..tostring(random(9999)),
+		belong = "1002"
+	}
+	local vehicle = GetEntityByID(id)
+
+	if vehicle and team then
+		local hover = 1.5 * vehicle:GetSize().y
+    	local pos = GetCameraPos()
+		vehicle:SetPosition(pos)
+		vehicle:SetRandomSkin()
+		team:AddChild(vehicle)
+    end
+
+    println(enemyname)
+end
+
+function SetGameTime( h, m )
+
+	if g_ObjCont ~= nil then
+		local CurrentDate = g_ObjCont:GetGameTime().AsNumList
+
+		g_ObjCont:SetGameTime( h, m, CurrentDate[2], CurrentDate[3], CurrentDate[4] )
+		UpdateWeather()
+	end
+
+end

--- a/patch/scripts/debug.lua
+++ b/patch/scripts/debug.lua
@@ -78,7 +78,7 @@ function DebugCreate( PrototypeName, Belong )
 end
 
 
-function CreateVehicleEx( PrototypeName, Name, pos, belong )
+function CreateVehicleEx( PrototypeName, Name, pos, belong, rot )
 	local bel
 
 	if belong then
@@ -100,12 +100,9 @@ function CreateVehicleEx( PrototypeName, Name, pos, belong )
 		return nil
 	end
 
---	by Anton: это не нужно, т.к. вызываем SetGamePositionOnGround()
---	local hover = 1.5 * vehicle:GetSize().y
---	pos.y = g_ObjCont:GetHeight( pos.x, pos.z ) + hover
-
-
 	vehicle:SetGamePositionOnGround( pos )
+
+	if rot then vehicle:SetRotation(rot) end
 
 	return vehicle
 end

--- a/remaster/data/scripts/compatch.lua
+++ b/remaster/data/scripts/compatch.lua
@@ -1,8 +1,28 @@
-CP_VERSION = "1.12 HD"
+CP_VERSION = "1.14 HD"
 
 -- by zatinu322:
 -- showing first narrator's text
 -- moved here, becouse this text has different speed in patch and remaster
 function ShowFirstNarratorText()
     AddCinematicMessage( 77772, 0.1)
+end
+
+-- paint trailer to main vehicle's skin
+function PaintTrailer( vehicleName )
+    local veh = getObj( vehicleName )
+    if not veh then
+        println("Error: attempt to index a nil value: "..vehicleName)
+        LOG("Error: attempt to index a nil value: "..vehicleName)
+        return
+    end
+
+	local trailer = veh:GetTrailer()
+    if not trailer then
+        println("Error: prototype "..vehicleName.." has no trailer.")
+        LOG("Error: prototype "..vehicleName.." has no trailer.")
+        return
+    end
+
+	local skinnum = veh:GetSkin()
+	trailer:SetSkin(skinnum)
 end


### PR DESCRIPTION
Постарался сделать так, чтобы катсцена с тюремным корованом ТСП не выглядела настолько плохо.
Также немного пофиксил контент-дизайн.

Помимо прочего добавил функцию `PaintTrailer(vehName)`, окрашивающую трейлер машины в цвет самой машины, и добавил аргумент `rot` к функции `CreateVehicleEx`, чтобы было проще создавать болванчиков в катсценах. 

И навёл порядок в camera_paths.xml для Хеля, раз уж влез туда. Добавил комментарии к путям и выпилил те, которые не используются.

Что я тестил:
1. Взяли квест, поехали на склад, убили всех.
2. Взяли квест, выяснили в Ольме, где держат лидера, поехали и спасли его.
3. Взяли квест, выяснили в Ольме, где держат лидера, поехали туда и случайно убили его прицеп.
4. Взяли квест, выяснили в Ольме, где держат лидера, забили и поехали на склад всех убивать.
5. Взяли квест, выяснили в Ольме, где держат лидера, поехали туда, посмотрели новую катсцену и без драки с корованом поехали на склад всех убивать.

Сейв для тестов: 
[00000002.zip](https://github.com/DeusExMachinaTeam/EM-CommunityPatch/files/12419464/00000002.zip)
