### PR TITLE
r4m1_FindMilitaryBase 'OnTake' fix

### DIFF
--- a/patch/gamedata/quests.xml
+++ b/patch/gamedata/quests.xml
@@ -278,7 +278,7 @@
 		CheckAll="0"
 		ConditionToGive="all complete"
 		PrecedingQuests="r4m1_RescueBuharsCivilian r3m1_FindNative_2"
-		OnTake='ShowCircleOnMinimapByName("ToR4M2");AddFadingMsgId( "fm_take_quest" )' />
+		OnTake='ShowCircleOnMinimapByName("ToR4M2")' />
 
 	<quest
 		Name="r4m1_FindMilitaryBase"
@@ -287,7 +287,7 @@
 		CheckAll="0"
 		ConditionToGive="all complete"
 		PrecedingQuests="r4m1_RescueBuharsCivilian r3m1_FindNative"
-		OnTake='ShowCircleOnMinimapBName("ToR4M2");AddFadingMsgId( "fm_take_quest" )' />
+		OnTake='ShowCircleOnMinimapByName("ToR4M2")' />
 <!--Root/r3m2/Сюжетные--><!--Root/r3m2/Опциональнае--><!--Root/r3m2/Опциональнае/Поле со знаками-->
 	<quest
 		Name="q_PlaceWithSign"


### PR DESCRIPTION
Убрал опечатку, и заодно удалил AddFadingMsg, потому что они и без этого отображаются при каждом взятии квеста, дополнительно это указывать не нужно. А так они два раза показывались, получается