### PR TITLE
English localization fixes

### DIFF
--- a/options/english_localization/data/if/strings/clansdiz.xml
+++ b/options/english_localization/data/if/strings/clansdiz.xml
@@ -510,7 +510,7 @@
 
 	<string
 		id="Belong_1017_diz"
-		value="This mysterious organization has adepts all over the world. Although the active support of AR has somewhat tarnished their reputation as seekers of truth and order, the Church's influence is considerable." />
+		value="This mysterious organization has adepts all over the world. Although the active support of CD has somewhat tarnished their reputation as seekers of truth and order, the Church's influence is considerable." />
 
 	<string
 		id="Belong_1018_diz"
@@ -618,7 +618,7 @@
 
 	<string
 		id="Belong_1053_diz"
-		value="The people of Sel remain neutral and supply power to both warring sides. No one but them can maintain the power plant, so they have not been attacked so far." />
+		value="The people of Seil remain neutral and supply power to both warring sides. No one but them can maintain the power plant, so they have not been attacked so far." />
 
 	<string
 		id="Belong_1054_diz"

--- a/options/english_localization/data/maps/r2m2/strings.xml
+++ b/options/english_localization/data/maps/r2m2/strings.xml
@@ -85,7 +85,7 @@
 		modelName="gadget_12"
 		modelSlot="1"
 		sound="data\sounds\Speech\r2m2\r2m2_10_cd_officer_radio.ogg"
-		value="The enemies are defeated! Without their leaders, they cannot stand against us! You have brought the glorious hour of victory closer and will be generously rewarded. Zion, the secret city of Axel, awaits you."
+		value="The enemies are defeated! Without their leaders, they cannot stand against us! You have brought the glorious hour of victory closer and will be generously rewarded. Zeon, the secret city of Axel, awaits you."
 		time="8" />
 
 	<string

--- a/options/english_localization_compatch/data/if/dialogs/credits.xml
+++ b/options/english_localization_compatch/data/if/dialogs/credits.xml
@@ -107,7 +107,7 @@
 
 		<Page
 			id="12"
-			text="Artists|| Rustam «Rychi» Turey| Evgeny  Tokarev| Sergey «Sega» Mitryaev| Viktor «isymbosi» Koryakin| Roman Latynov"
+			text="Artists|| Rustam «Rychi» Turey| Evgeny Tokarev| Sergey «Sega» Mitryaev| Viktor «isymbosi» Koryakin| Roman Latynov"
 			modelName	= "r3_man"
 			modelSkin="1"
 			modelCfg="1529"
@@ -314,7 +314,7 @@
 
 		<Page
 			id="34_1"
-			text="External testing||Igor Peshekhontsev|Dmitry Chichikov|Alexey SHekhovtsev|Ilia Yusipov|Timur Yusipov"
+			text="External testing||Igor Peshekhontsev|Dmitry Chichikov|Alexey Shekhovtsev|Ilia Yusipov|Timur Yusipov"
 			modelName	= "r3_man"
 			modelSkin	= "1"
 			modelCfg	= "0"
@@ -332,7 +332,7 @@
 
 		<Page
 			id="36"
-			text="Sales department ||Andrey Osipov|Alexandr Petrinsky|Olga Polkovnikova|Larisa Savelieva |Evgeny Samsonov |Svetlana Samsonova |Valery Tikhvonski|Sergey Fedosof"
+			text="Sales department ||Andrey Osipov|Alexandr Petrinsky|Olga Polkovnikova|Larisa Savelieva |Evgeny Samsonov |Svetlana Samsonova |Valery Tikhvonski|Sergey Fedosov"
 			modelName	= "r2_woman"
 			modelSkin	= "0"
 			modelCfg	= "4"

--- a/options/english_localization_compatch/data/if/strings/uidescription.xml
+++ b/options/english_localization_compatch/data/if/strings/uidescription.xml
@@ -34,7 +34,7 @@
 
 	<string
 		id="sml4Cab01_diz"
-		value="Grasshopper's ca.b" />
+		value="Grasshopper's cab." />
 
 	<string
 		id="denscoutCab_diz"
@@ -594,7 +594,7 @@
 
 	<string
 		id="mirotvorecCargo01_diz"
-		value="Standard body of the Peacekeeper. Lost of armor, plenty of cargo space, place for a good gun." />
+		value="Standard body of the Peacekeeper. Lots of armor, plenty of cargo space, place for a good gun." />
 
 	<string
 		id="mirotvorecCargo02_diz"
@@ -750,7 +750,7 @@
 	<string
 		id="quest_disk_1_diz"
 		locForm="0"
-		value="The disc that used to belong to Ivan Go. Surely this item must be of great value." />
+		value="A disc made of thin plastic. Surely this item must be of great value." />
 
 	<string
 		id="quest_disk_2_diz"

--- a/options/english_localization_comrem/data/if/dialogs_16_9/credits.xml
+++ b/options/english_localization_comrem/data/if/dialogs_16_9/credits.xml
@@ -110,7 +110,7 @@
 
 		<Page
 			id="12"
-			text="Artists||Rustam «Rychi» Turey|Evgeny  Tokarev|Sergey «Sega» Mitryaev|Viktor «isymbosi» Koryakin|Roman Latynov"
+			text="Artists||Rustam «Rychi» Turey|Evgeny Tokarev|Sergey «Sega» Mitryaev|Viktor «isymbosi» Koryakin|Roman Latynov"
 			modelName="r3_man"
 			modelSkin="1"
 			modelCfg="1529"
@@ -317,7 +317,7 @@
 
 		<Page
 			id="34_1"
-			text="External testing||Igor Peshekhontsev|Dmitry Chichikov|Alexey SHekhovtsev|Ilia Yusipov|Timur Yusipov"
+			text="External testing||Igor Peshekhontsev|Dmitry Chichikov|Alexey Shekhovtsev|Ilia Yusipov|Timur Yusipov"
 			modelName="r3_man"
 			modelSkin="1"
 			modelCfg="0"
@@ -335,7 +335,7 @@
 
 		<Page
 			id="36"
-			text="Sales department||Andrey Osipov|Alexandr Petrinsky|Olga Polkovnikova|Larisa Savelieva|Evgeny Samsonov|Svetlana Samsonova|Valery Tikhvonski|Sergey Fedosof"
+			text="Sales department||Andrey Osipov|Alexandr Petrinsky|Olga Polkovnikova|Larisa Savelieva|Evgeny Samsonov|Svetlana Samsonova|Valery Tikhvonski|Sergey Fedosov"
 			modelName="r2_woman"
 			modelSkin="0"
 			modelCfg="4"

--- a/options/english_localization_comrem/data/if/strings/uidescription.xml
+++ b/options/english_localization_comrem/data/if/strings/uidescription.xml
@@ -594,7 +594,7 @@
 
 	<string
 		id="mirotvorecCargo01_diz"
-		value="Standard body of the Peacekeeper. Lost of armor, plenty of cargo space, place for a good gun." />
+		value="Standard body of the Peacekeeper. Lots of armor, plenty of cargo space, place for a good gun." />
 
 	<string
 		id="mirotvorecCargo02_diz"
@@ -750,7 +750,7 @@
 	<string
 		id="quest_disk_1_diz"
 		locForm="0"
-		value="The disc that used to belong to Ivan Go. Surely this item must be of great value." />
+		value="A disc made of thin plastic. Surely this item must be of great value." />
 
 	<string
 		id="quest_disk_2_diz"


### PR DESCRIPTION
#503 

### uidescription and strings changes:

- **"AR" in COD diz replaced with "CD"**
![image](https://github.com/user-attachments/assets/c1d20c32-c233-4da0-910e-5ec9ed42026a)

- **Sel replace with Seil**
![image](https://github.com/user-attachments/assets/a0a0b091-b3f7-4a24-b59f-28278190a05f)

- **Zion replaced with Zeon**
![image](https://github.com/user-attachments/assets/33ebd5f7-816b-40a7-a350-e5aa6e700e28)

- **In ComPatch uidescription replaced wrong dot in sml4 cab01 diz**
![image](https://github.com/user-attachments/assets/cef275f4-75f4-45bc-a3a2-cf17ed62a930)


- **In both uidescription `Lost` in Mirotvorec cargo01 diz replaced with `Lots` and quest first disk item diz fixed. Translates sentence from russian localization: `A disk made of thin plastic` instead of `The disk that used to belong to Ivan Go`. **
![image](https://github.com/user-attachments/assets/b8189313-5b3e-4d92-8519-a05d384de497)
![image](https://github.com/user-attachments/assets/2b6afc10-e843-43bd-91da-b5ef5520506f)

-------------------------------

### credits.xml changes:

- **ID 12 - Removed extra space between Evgeniy Tokarev's first and last name**
![image](https://github.com/user-attachments/assets/ea32fa36-6422-4374-b734-e6dd9b1b5560)

- **ID 34_1 - "SHekovtsev" replaced with "Shekhovtsev"**
![image](https://github.com/user-attachments/assets/236ce833-9577-4ce3-aaa7-17d342d9ee76)

- **ID 36 - "Fedosof" replaced with "Fedosov"**
![image](https://github.com/user-attachments/assets/8ec7731f-efe0-4334-9524-b951c6461ffb)